### PR TITLE
Set all `Color` and `Brushes` to `StaticResources`

### DIFF
--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -68,16 +68,16 @@
 	
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.5" />
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.Core" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.ListView" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="20.3.56" />
-	  <PackageReference Include="Syncfusion.Maui.TabView" Version="20.3.56" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.7" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.Core" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.ListView" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="20.3.57" />
+	  <PackageReference Include="Syncfusion.Maui.TabView" Version="20.3.57" />
 	</ItemGroup>
 	
 
@@ -87,6 +87,10 @@
 	  </Compile>
 	  <Compile Update="Themes\ItemTemplates\ListViewHeaderTemplates.xaml.cs">
 	    <DependentUpon>ListViewHeaderTemplates.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="Themes\ItemTemplates\GeneralItemTemplates.xaml.cs">
+	    <SubType>Code</SubType>
+	    <DependentUpon>GeneralItemTemplates.xaml</DependentUpon>
 	  </Compile>
 	  <Compile Update="Themes\ItemTemplates\ListViewSwipeTemplates.xaml.cs">
 	    <DependentUpon>ListViewSwipeTemplates.xaml</DependentUpon>
@@ -229,6 +233,10 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Themes\ItemTemplates\ListViewHeaderTemplates.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Themes\ItemTemplates\GeneralItemTemplates.xaml">
+	    <SubType>Designer</SubType>
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Themes\ItemTemplates\ListViewSwipeTemplates.xaml">

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj.user
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj.user
@@ -126,6 +126,9 @@
     <MauiXaml Update="Themes\ItemTemplates\ListViewHeaderTemplates.xaml">
       <SubType>Designer</SubType>
     </MauiXaml>
+    <MauiXaml Update="Themes\ItemTemplates\GeneralItemTemplates.xaml">
+      <SubType>Designer</SubType>
+    </MauiXaml>
     <MauiXaml Update="Themes\ItemTemplates\ListViewSwipeTemplates.xaml">
       <SubType>Designer</SubType>
     </MauiXaml>

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/Controls/Grid.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/Controls/Grid.xaml
@@ -72,6 +72,7 @@
 
     <!--  Common style for Shell.TitleView -->
     <Style x:Key="ShellTitleViewGridStyle" TargetType="Grid">
-        <!--<Setter Property="HeightRequest" Value="{OnPlatform iOS=44}" />-->
+        <!--<Setter Property="HeightRequest" Value="150" />-->
+        <!--<Setter Property="Padding" Value="0, 10" />-->
     </Style>
 </ResourceDictionary>

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/Controls/Syncfusion/SfRangeSlider.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/Controls/Syncfusion/SfRangeSlider.xaml
@@ -23,8 +23,8 @@
                                     <sliders:SliderTrackStyle
                                         ActiveSize="8" 
                                         InactiveSize="6" 
-                                        ActiveFill="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={DynamicResource LightGray}}" 
-                                        InactiveFill="{AppThemeBinding Light={DynamicResource DarkGray}, Dark={DynamicResource LightGray}}"
+                                        ActiveFill="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource LightGray}}" 
+                                        InactiveFill="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}"
                                         />
                                 </Setter.Value>
                             </Setter>
@@ -32,8 +32,8 @@
                                 <Setter.Value>
                                     <sliders:SliderThumbStyle
                                         Radius = "13"
-                                        Fill="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={DynamicResource LightGray}}"
-                                        Stroke="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={DynamicResource LightGray}}"
+                                        Fill="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource LightGray}}"
+                                        Stroke="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource LightGray}}"
                                         StrokeThickness="3"
                                         />
                                 </Setter.Value>
@@ -41,8 +41,8 @@
                             <Setter Property="LabelStyle">
                                 <Setter.Value>
                                     <sliders:SliderLabelStyle
-                                        ActiveTextColor = "{AppThemeBinding Light={DynamicResource Black}, Dark={DynamicResource White}}"
-                                        InactiveTextColor="{AppThemeBinding Light={DynamicResource Gray600}, Dark={DynamicResource Gray400}}"
+                                        ActiveTextColor = "{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+                                        InactiveTextColor="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}"
                                         ActiveFontSize="16"
                                         InactiveFontSize="14"
                                         />
@@ -57,8 +57,8 @@
                                     <sliders:SliderTrackStyle
                                         ActiveSize="10" 
                                         InactiveSize="8"
-                                        ActiveFill="{AppThemeBinding Light={DynamicResource DarkGray}, Dark={DynamicResource LightGray}}" 
-                                        InactiveFill="{AppThemeBinding Light={DynamicResource LightGray}, Dark={DynamicResource DarkGray}}"
+                                        ActiveFill="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" 
+                                        InactiveFill="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"
                                         />
                                 </Setter.Value>
                             </Setter>
@@ -66,8 +66,8 @@
                                 <Setter.Value>
                                     <sliders:SliderThumbStyle
                                         Radius = "13"
-                                        Fill="{AppThemeBinding Light={DynamicResource LightGray}, Dark={DynamicResource DarkGray}}"
-                                        Stroke="{AppThemeBinding Light={DynamicResource LightGray}, Dark={DynamicResource DarkGray}}"
+                                        Fill="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"
+                                        Stroke="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"
                                         StrokeThickness="3"
                                         />
                                 </Setter.Value>
@@ -75,8 +75,8 @@
                             <Setter Property="LabelStyle">
                                 <Setter.Value>
                                     <sliders:SliderLabelStyle
-                                        ActiveTextColor = "{AppThemeBinding Light={DynamicResource LightGray}, Dark={DynamicResource DarkGray}}"
-                                        InactiveTextColor="{AppThemeBinding Light={DynamicResource LightGray}, Dark={DynamicResource DarkGray}}"
+                                        ActiveTextColor = "{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"
+                                        InactiveTextColor="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"
                                         ActiveFontSize="14"
                                         InactiveFontSize="16"
                                         />

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/Controls/Syncfusion/SfTabView.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/Controls/Syncfusion/SfTabView.xaml
@@ -50,19 +50,19 @@
     <Style TargetType="tabView:SfTabItem" BasedOn="{StaticResource DefaultTabViewItemStyle}"/>
     <!--
     <Style x:Key="DefaultTabViewItemDefaultStyle" TargetType="tabView:SfTabItem">
-        <Setter Property="TitleFontColor" Value="{AppThemeBinding Light={DynamicResource Black}, Dark={DynamicResource White}}"/>
+        <Setter Property="TitleFontColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"/>
         <Setter Property="SelectionColor" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="TitleFontSize" Value="{OnIdiom Desktop=36, Tablet=14, Default=12}"/>
         <Setter Property="TitleFontFamily" Value="{StaticResource MontserratMedium}"/>
         <Setter Property="FontIconFontSize" Value="{OnIdiom Desktop=36, Tablet=20, Default=16}"/>
-        <Setter Property="FontIconFontColor" Value="{AppThemeBinding Light={DynamicResource Gray800}, Dark={DynamicResource Gray200}}"/>
+        <Setter Property="FontIconFontColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
         <Setter Property="FontIconFontFamily" Value="{StaticResource MaterialDesignIcons}"/>
     </Style>
 
     <Style TargetType="tabView:SfTabItem" BasedOn="{StaticResource DefaultTabViewItemDefaultStyle}"/>
 
     <Style x:Key="ChildTabViewItemDefaultStyle" TargetType="tabView:SfTabItem" BasedOn="{StaticResource DefaultTabViewItemDefaultStyle}">
-        <Setter Property="TitleFontColor" Value="{AppThemeBinding Light={DynamicResource Gray800}, Dark={DynamicResource Gray200}}"/>
+        <Setter Property="TitleFontColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
         <Setter Property="TitleFontSize" Value="{OnIdiom Desktop=24, Tablet=12, Default=10}"/>
         <Setter Property="FontIconFontSize" Value="{OnIdiom Desktop=24, Tablet=18, Default=14}"/>
     </Style>

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/DefaultTheme.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/DefaultTheme.xaml
@@ -40,6 +40,7 @@
         <ResourceDictionary Source="/Themes/Controls/TimePicker.xaml" />
 
         <!-- Item Templates -->
+        <ResourceDictionary Source="/Themes/ItemTemplates/GeneralItemTemplates.xaml" />
         <ResourceDictionary Source="/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml" />
         <ResourceDictionary Source="/Themes/ItemTemplates/ListViewHeaderTemplates.xaml" />
         <ResourceDictionary Source="/Themes/ItemTemplates/ListViewItemTemplates.xaml" />

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/GeneralItemTemplates.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/GeneralItemTemplates.xaml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Themes.ItemTemplates.GeneralItemTemplates"
+    
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"
+    
+    xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"    
+    xmlns:listView="clr-namespace:Syncfusion.Maui.ListView;assembly=Syncfusion.Maui.ListView"
+    >
+    <converters:UriToStringConverter x:Key="UriToStringConverter" />
+
+    <DataTemplate x:Key="TutorialStepItemTemplate" x:DataType="documentation:TutorialStep">
+        <Grid 
+            Padding="8,6"
+            ColumnSpacing="4"
+            RowSpacing="4"
+            RowDefinitions="*,64,Auto"
+            >
+            <!-- BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" -->
+            <Frame
+                Margin="20,16"
+                BorderColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                >
+                <Image
+                    Margin="4"
+                    Source="{Binding Image, Converter={StaticResource UriToStringConverter}}"
+                    Aspect="AspectFit"
+                    />
+            </Frame>
+            <Label 
+                Grid.Row="1"
+                Text="{Binding Heading}"
+                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                VerticalTextAlignment="End"
+                HorizontalTextAlignment="Center"
+                />
+
+            <Label
+                Grid.Row="2"
+                Style="{StaticResource LabelStyle}"
+                Text="{Binding Content}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                LineBreakMode="WordWrap"
+                Margin="4,12"
+                />
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/GeneralItemTemplates.xaml.cs
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/GeneralItemTemplates.xaml.cs
@@ -1,0 +1,9 @@
+namespace AndreasReitberger.Shared.Themes.ItemTemplates;
+
+public partial class GeneralItemTemplates : ResourceDictionary
+{
+    public GeneralItemTemplates()
+    {
+        InitializeComponent();
+    }
+}

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -20,12 +20,8 @@
                 Padding="8,6"
                 ColumnSpacing="4"
                 RowSpacing="4"
+                ColumnDefinitions="Auto,*"
                 >
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition />
-                </Grid.ColumnDefinitions>
-
                 <!-- Check icon -->
                 <Border
                     Style="{StaticResource ProfileBorderStyle}"
@@ -200,7 +196,7 @@
                     <Label 
                         LineBreakMode="NoWrap" 
                         Style="{StaticResource PrimaryLabelStyle}" 
-                        TextColor="{DynamicResource White}"
+                        TextColor="{StaticResource White}"
                         Text="{Binding Name}"
                         />
                     <!-- Translator -->
@@ -208,7 +204,7 @@
                         Style="{StaticResource LabelStyle}" 
                         LineBreakMode="WordWrap" 
                         Text="{Binding Translator}"
-                        TextColor="{DynamicResource White}"
+                        TextColor="{StaticResource White}"
                         FontSize="12"
                         />
                 </StackLayout>
@@ -232,7 +228,7 @@
                     Text="{Binding Changelog}"
                     />
                 <Border 
-                    BackgroundColor="{AppThemeBinding Light={DynamicResource Gray200}, Dark={DynamicResource Gray800}}" 
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
                     Style="{StaticResource ProfileBorderStyle}"
                     Grid.Column="1"
                     VerticalOptions="Center"

--- a/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/source/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -36,15 +36,13 @@
 
     <DataTemplate x:Key="DeleteGestureSwipeTemplate">
         <ViewCell>
-            <Grid
-                BackgroundColor="{StaticResource Red}"
-                >
                 <Label
                     Style="{StaticResource IconLabelStyle}"
                     Text="{StaticResource Delete}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
+                    BackgroundColor="{StaticResource Red}"
                     Margin="0"
                     >
                     <Label.GestureRecognizers>
@@ -55,7 +53,12 @@
                             />
                     </Label.GestureRecognizers>
                 </Label>
+            <!--
+            <Grid
+                BackgroundColor="{StaticResource Red}"
+                >
             </Grid>
+            -->
         </ViewCell>
     </DataTemplate>
 
@@ -205,7 +208,7 @@
                 <Border
                     Margin="0,8"
                     BackgroundColor="{DynamicResource PrimaryColor}"
-                    Stroke="{AppThemeBinding Light={DynamicResource Gray100}, Dark={DynamicResource Gray900}}"
+                    Stroke="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
                     StrokeThickness="0"
                     >
                     <Border.StrokeShape>


### PR DESCRIPTION
This PR brings following changes.

- Changed all `DynamicResources` to `StaticResources`, but the ones leading to `PrimaryColor`.
- Updated nugets
- Added a `ItemTemplate` for the `TutorialStep` class

Fixes #8 