### PR TITLE
Moved re-usable `CarouselViewItemTemplates` to shared library

### DIFF
--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Themes.ItemTemplates.CarouselViewItemTemplates"
+    
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
+    xmlns:theme="clr-namespace:AndreasReitberger.Shared.Core.Theme;assembly=SharedMauiCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"  
+    xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"   
+    xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons"
+    >
+    <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
+    <converters:ColorToStringConverter x:Key="ColorToStringConverter" />
+
+    <DataTemplate x:Key="DefaultThemeColorInfoItemTemplate" x:DataType="theme:ThemeColorInfo">
+        <Grid>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="CurrentItem">
+                        <VisualState.Setters>
+                            <Setter Property="Rotation" Value="0" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PreviousItem">
+                        <VisualState.Setters>
+                            <Setter Property="Rotation" Value="-10" />
+                            <Setter Property="Opacity" Value="0.35" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="NextItem">
+                        <VisualState.Setters>
+                            <Setter Property="Rotation" Value="10" />
+                            <Setter Property="Opacity" Value="0.35" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="DefaultItem">
+                        <VisualState.Setters>
+                            <Setter Property="Opacity" Value="0.25" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Border
+                StrokeShape="RoundRectangle 20"
+                StrokeThickness="0"
+                Margin="0,10"
+                BackgroundColor="{Binding PrimaryColor}"
+                >
+                <Border.Shadow>
+                    <Shadow 
+                        Opacity="0.5"
+                        Radius="12"
+                        Offset="0, 12"
+                        />
+                </Border.Shadow>
+                <Grid
+                    RowDefinitions="Auto,*"
+                    >
+                    <Label
+                        Text="{Binding ThemeName}"
+                        Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                        TextColor="{Binding PrimaryColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                        VerticalTextAlignment="Center"
+                        HorizontalTextAlignment="Center"
+                        Margin="10,20"
+                        />
+                    <!--
+                    <VerticalStackLayout
+                        Grid.Row="1"
+                        >
+                        <Border
+                            StrokeShape="RoundRectangle 10"
+                            StrokeThickness="0"
+                            Margin="20,10"
+                            BackgroundColor="{Binding PrimaryLigtherColor}"
+                            >
+                            <Label
+                                Text="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToStringConverter}}"
+                                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                                TextColor="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                                VerticalTextAlignment="Center"
+                                HorizontalTextAlignment="Center"
+                                Margin="10,20"
+                                />
+                        </Border>
+                        <Border
+                            StrokeShape="RoundRectangle 10"
+                            StrokeThickness="0"
+                            Margin="20,10"
+                            BackgroundColor="{Binding PrimaryDarkerColor}"
+                            >
+                            <Label
+                                Text="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToStringConverter}}"
+                                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                                TextColor="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                                VerticalTextAlignment="Center"
+                                HorizontalTextAlignment="Center"
+                                Margin="10,20"
+                                />
+                        </Border>
+                    </VerticalStackLayout>
+                    -->
+                </Grid>
+            </Border>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml.cs
@@ -1,0 +1,9 @@
+namespace AndreasReitberger.Shared.Themes.ItemTemplates;
+
+public partial class CarouselViewItemTemplates : ResourceDictionary
+{
+    public CarouselViewItemTemplates()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedTemplates.xaml
@@ -11,5 +11,7 @@
         <ResourceDictionary Source="/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml" />
         <ResourceDictionary Source="/Resources/Themes/ItemTemplates/ListViewHeaderTemplates.xaml" />
         <ResourceDictionary Source="/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml" />
+        
+        <ResourceDictionary Source="/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -54,9 +54,18 @@
 
 	<ItemGroup>
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.11" />
+	</ItemGroup>
+	
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\SharedMauiCoreLibrary\src\SharedMauiCoreLibrary\SharedMauiCoreLibrary.csproj" />
 	</ItemGroup>	
 
 	<ItemGroup>
+	  <Compile Update="Resources\Themes\ItemTemplates\CarouselViewItemTemplates.xaml.cs">
+	    <SubType>Code</SubType>
+	    <DependentUpon>CarouselViewItemTemplates.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Resources\Themes\MinimalisticTheme.xaml.cs">
 	    <DependentUpon>MinimalisticTheme.xaml</DependentUpon>
 	  </Compile>
@@ -175,6 +184,9 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Resources\Themes\Controls\StackLayout.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Resources\Themes\ItemTemplates\CarouselViewItemTemplates.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Resources\Themes\MinimalisticTheme.xaml">


### PR DESCRIPTION
This commit moves re-usable `CarouselViewItemTemplates` to the shared style library instead of keeping them in each app project.

Fixed #47 