### PR TITLE
Removed `MSBuild:Compile` from `Styles`

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -99,6 +99,7 @@
 	  </Compile>
 	</ItemGroup>
 
+	<!-- Maui Samples styles do not have the Compile attribute, maybe this causes problems for Intelisense.
 	<ItemGroup>
 	  <MauiXaml Update="Resources\Themes\Controls\Core\EnhancedListView.xaml">
 	    <Generator>MSBuild:Compile</Generator>
@@ -187,5 +188,6 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>
+	-->
 
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -54,7 +54,7 @@
 	
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiXamlStylesLibrary" Version="1.1.1" />
+	  <PackageReference Include="SharedMauiXamlStylesLibrary" Version="1.1.2" />
 	  <PackageReference Include="Syncfusion.Maui.Charts" Version="22.1.34" />
 	  <PackageReference Include="Syncfusion.Maui.Core" Version="22.1.34" />
 	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="22.1.34" />

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -94,6 +94,7 @@
 	  </Compile>
 	</ItemGroup>
 
+	<!--
 	<ItemGroup>
 	  <MauiXaml Update="Resources\Themes\Controls\Border.xaml">
 	    <Generator>MSBuild:Compile</Generator>
@@ -219,5 +220,6 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>
+	-->
 
 </Project>


### PR DESCRIPTION
This commit removes the `MSBuild:Compile` from all `Style` files.

Fixed #146