### PR TITLE
Fixed missing key `LinkButton`

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.1.2</Version>
+        <Version>1.1.3</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/SharedMauiXamlStyles</PackageProjectUrl>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -123,8 +123,7 @@
         <Setter Property="FontSize" Value="Caption" />
     </Style>
 
-
-    <Style x:Key="LinkRoundButtonStyle" TargetType="Button" BasedOn="{StaticResource LinkButton}">
+    <Style x:Key="LinkRoundButtonStyle" TargetType="Button" BasedOn="{StaticResource LinkButtonStyle}">
         <Setter Property="BorderColor" Value="{StaticResource Blue}" />
         <Setter Property="BorderWidth" Value="2" />
         <Setter Property="HeightRequest" Value="50" />


### PR DESCRIPTION
This PR fixes the missing `LinkButton` key. The key changed to `LinkButtonStyle`, but some other `Style` was still based on the old key, which lead to an exception.

Fixed #150