### PR TITLE
Change `BackgroundColor` to `Background`

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ButtonsPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ButtonsPage.xaml
@@ -36,6 +36,13 @@
             
             <Button 
                 Margin="8,16"
+                Text="This is a green button"
+                Style="{StaticResource DefaultButtonStyle}"
+                Background="Green"
+                />
+            
+            <Button 
+                Margin="8,16"
                 Text="This is a link styled button"
                 Style="{StaticResource LinkButtonStyle}"
                 />
@@ -70,25 +77,19 @@
             <Button 
                 Margin="8,16"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Favourite}"
-                Style="{StaticResource IconButtonStyle}"
-                Background="{DynamicResource PrimaryColor}"
-                TextColor="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                Style="{StaticResource PrimaryIconButtonStyle}"
                 />
             <Button 
                 Grid.Column="1"
                 Margin="8,16"
                 Text="{x:Static icons:MaterialIcons.PhonePlusOutline}"
-                Style="{StaticResource MaterialDesignIconButtonStyle}"
-                Background="{DynamicResource PrimaryColor}"
-                TextColor="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                Style="{StaticResource PrimaryMaterialDesignIconButtonStyle}"
                 />
             <Button 
                 Grid.Column="2"
                 Margin="8,16"
                 Text="{x:Static icons:MaterialIcons.ProgressCheck}"
-                Style="{StaticResource RoundMaterialDesignIconButtonStyle}"
-                Background="{DynamicResource PrimaryColor}"
-                TextColor="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                Style="{StaticResource PrimaryMaterialDesignIconButtonStyle}"
                 />
             <Button 
                 Grid.Row="1"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/Core/EnhancedListView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/Core/EnhancedListView.xaml
@@ -17,7 +17,7 @@
         <Setter Property="SelectionBackground" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="controls:EnhancedListView">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAccordion.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAccordion.xaml
@@ -17,7 +17,7 @@
 
     <!-- Docs: https://help.syncfusion.com/maui/accordion/ -->
     <Style x:Key="DefaultAccordionStyle" TargetType="expander:SfAccordion">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
     
     <Style x:Key="DefaultAccordionItemStyle" TargetType="expander:AccordionItem">

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAutoComplete.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAutoComplete.xaml
@@ -19,7 +19,7 @@
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
         <!-- Seems to cause a crash -->
         <!--<Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>-->
@@ -46,7 +46,7 @@
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
         <!-- Seems to cause a crash -->
         <!--<Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>-->

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
@@ -33,7 +33,7 @@
         <Setter Property="ChipTextColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
         <Setter Property="ChipBackground" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
         <Setter Property="ChipTextSize" Value="12" />
-        <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="SelectionIndicatorColor" Value="{StaticResource Pink}" />
         <Setter Property="ChipLayout">
             <Setter.Value>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
@@ -22,8 +22,8 @@
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
         <!--<Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>-->
         <Setter Property="Margin" Value="4,2"/>
-        <!--<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />-->
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" /><!---->
+        <!--<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />-->
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" /><!---->
         <!--
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfExpander.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfExpander.xaml
@@ -19,7 +19,7 @@
     <Style x:Key="DefaultExpanderStyle" TargetType="expander:SfExpander">
         <Setter Property="HeaderBackground" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="HeaderIconColor" Value="{Binding Source={RelativeSource Self}, Path=HeaderBackground, Converter={StaticResource ColorToBlackWhiteConverter}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
         <Setter Property="AnimationDuration" Value="200" />
         <Setter Property="HeaderIconPosition" Value="Start" />
         <Setter Property="VisualStateManager.VisualStateGroups">

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfListView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfListView.xaml
@@ -16,7 +16,7 @@
         <Setter Property="SelectionBackground" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="listView:SfListView">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfNumericEntry.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfNumericEntry.xaml
@@ -23,7 +23,7 @@
         <Setter Property="IsEditable" Value="True" />
         <Setter Property="ShowClearButton" Value="True" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="UpDownPlacementMode" Value="Inline" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -28,7 +28,7 @@
                 <!-- Check icon -->
                 <Border
                     Style="{StaticResource ProfileBorderStyle}"
-                    BackgroundColor="{StaticResource LightGreen}"
+                    Background="{StaticResource LightGreen}"
                     Margin="0"
                     >
                     <Label 
@@ -175,7 +175,7 @@
             <Grid 
                 Padding="2"
                 Margin="1"
-                BackgroundColor="{DynamicResource PrimaryColor}"
+                Background="{DynamicResource PrimaryColor}"
                 ColumnDefinitions="48,*"
                 >
                 <Grid.RowDefinitions>
@@ -231,7 +231,7 @@
                     Text="{Binding Changelog}"
                     />
                 <Border 
-                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
+                    Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
                     Style="{StaticResource ProfileBorderStyle}"
                     Grid.Column="1"
                     VerticalOptions="Center"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -27,7 +27,7 @@
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
                 HorizontalTextAlignment="Center"
-                BackgroundColor="{StaticResource Red}"
+                Background="{StaticResource Red}"
                 Margin="0"
                 >
                 <Label.GestureRecognizers>
@@ -44,7 +44,7 @@
     <DataTemplate x:Key="EditGestureSwipeTemplate">
         <ViewCell>
             <Grid
-                BackgroundColor="{StaticResource Green}"
+                Background="{StaticResource Green}"
                 >
                 <Label
                     Style="{StaticResource IconLabelStyle}"
@@ -69,7 +69,7 @@
     <DataTemplate x:Key="ViewGestureSwipeTemplate">
         <ViewCell>
             <Grid
-                BackgroundColor="{StaticResource Blue}"
+                Background="{StaticResource Blue}"
                 >
                 <Label
                     Style="{StaticResource IconLabelStyle}"
@@ -98,7 +98,7 @@
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
                 HorizontalTextAlignment="Center"
-                BackgroundColor="{StaticResource Green}"
+                Background="{StaticResource Green}"
                 Margin="0"
                 >
                 <Label.GestureRecognizers>
@@ -120,7 +120,7 @@
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
                 HorizontalTextAlignment="Center"
-                BackgroundColor="{StaticResource Orange}"
+                Background="{StaticResource Orange}"
                 Margin="0"
                 >
                 <Label.GestureRecognizers>
@@ -147,7 +147,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Red}"
+                    Background="{StaticResource Red}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -165,7 +165,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Green}"
+                    Background="{StaticResource Green}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -191,7 +191,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Yellow}"
+                    Background="{StaticResource Yellow}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -210,7 +210,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Green}"
+                    Background="{StaticResource Green}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -236,7 +236,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Blue}"
+                    Background="{StaticResource Blue}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -254,7 +254,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Green}"
+                    Background="{StaticResource Green}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -272,7 +272,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Green}"
+                    Background="{StaticResource Green}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -298,7 +298,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Red}"
+                    Background="{StaticResource Red}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -316,7 +316,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Blue}"
+                    Background="{StaticResource Blue}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -341,7 +341,7 @@
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
-                    BackgroundColor="{StaticResource Green}"
+                    Background="{StaticResource Green}"
                     Margin="0"
                     >
                     <Label.GestureRecognizers>
@@ -360,7 +360,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Blue}"
+                    Background="{StaticResource Blue}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -385,7 +385,7 @@
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
-                    BackgroundColor="{StaticResource Orange}"
+                    Background="{StaticResource Orange}"
                     Margin="0"
                     >
                     <Label.GestureRecognizers>
@@ -404,7 +404,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    BackgroundColor="{StaticResource Green}"
+                    Background="{StaticResource Green}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -54,16 +54,16 @@
 	
 	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.Core" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.Expander" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.ListView" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="22.2.11" />
-	  <PackageReference Include="Syncfusion.Maui.TabView" Version="22.2.11" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.Core" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.Expander" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.ListView" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="23.1.36" />
+	  <PackageReference Include="Syncfusion.Maui.TabView" Version="23.1.36" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -96,6 +96,10 @@
 	    <SubType>Code</SubType>
 	    <DependentUpon>SharedFonts.xaml</DependentUpon>
 	  </Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 	</ItemGroup>
 
 	<!-- Maui Samples styles do not have the Compile attribute, maybe this causes problems for Intelisense.

--- a/src/SharedMauiXamlStylesLibrary/Controls/TapAnimationGrid.cs
+++ b/src/SharedMauiXamlStylesLibrary/Controls/TapAnimationGrid.cs
@@ -120,13 +120,13 @@ namespace AndreasReitberger.Shared.Controls
             TapAnimationGrid grid = (TapAnimationGrid)bindable;
             if (grid.IsAnimated)
             {
-                Application.Current.Resources.TryGetValue($"{(Application.Current.RequestedTheme == AppTheme.Light ? "Light_" : "Dark_")}Gray100", out var retVal);
-                grid.BackgroundColor = (Color)retVal;
+                Application.Current.Resources.TryGetValue($"{(Application.Current.RequestedTheme == AppTheme.Light ? "Gray100" : "Gray900")}", out var retVal);
+                grid.Background = (Brush)retVal;
 
                 // To make the selected item color changes for 100 milliseconds.
                 await Task.Delay(100);
                 Application.Current.Resources.TryGetValue("TaptemGridBackground", out var retValue);
-                grid.BackgroundColor = (Color)retValue;
+                grid.Background = (Brush)retValue;
             }
         }
         #endregion

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Border.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Border.xaml
@@ -35,7 +35,7 @@
         </Setter>
         <Setter Property="StrokeThickness" Value="1"/>
         <Setter Property="Shadow" Value="{StaticResource CardViewShadowStyle}"/>
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"/>
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"/>
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"/>
     </Style>
 
@@ -59,7 +59,7 @@
 
     <Style x:Key="BrightMinimalPanelCardViewBorderStyle" TargetType="Border" BasedOn="{StaticResource MinimalPanelCardViewBorderStyle}">
         <Setter Property="Margin" Value="4,8"/>
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
     </Style>
 
     <Style x:Key="CircleBorderStyle" TargetType="Border" BasedOn="{StaticResource ProfileBorderStyle}">
@@ -70,7 +70,7 @@
                 <RoundRectangle CornerRadius="{OnIdiom Phone=32, Default=36}" />
             </Setter.Value>
         </Setter>
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
 
     <Style x:Key="MenuSeparatorBorderStyle" TargetType="Border" BasedOn="{StaticResource ProfileBorderStyle}">
@@ -81,7 +81,7 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Margin" Value="1,2" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray600}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray600}}" />
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray600}}" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/BoxView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/BoxView.xaml
@@ -12,7 +12,7 @@
     <Style x:Key="SeparatorStyle" TargetType="BoxView">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
         <Setter Property="HeightRequest" Value="1" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
     </Style>
 
     <!--  Common style for separator BoxView  -->

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -5,7 +5,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
-    xmlns:localConcerters="clr-namespace:AndreasReitberger.Shared.Converters"
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons"
     >
     <!--
@@ -20,7 +19,7 @@
 
     <converters:ColorToLightForgroundConverter x:Key="ColorToLightForgroundConverter"  />
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
-    <localConcerters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
+    <converters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
 
     <Style x:Key="DefaultButtonStyle" TargetType="Button">
         <!-- Set Background before setting the TextColor due to the Converter -->

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -18,8 +18,8 @@
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
 
     <Style x:Key="DefaultButtonStyle" TargetType="Button">
-        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}" />
-        <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}"/>
+        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToBlackWhiteConverter}}" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <Setter Property="FontSize" Value="{OnPlatform 
             Android={OnIdiom Phone=14, Default=18}, 
@@ -32,15 +32,15 @@
                     <!--
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}" />
-                            <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}" />
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToBlackWhiteConverter}}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
                         </VisualState.Setters>
                     </VisualState>
                     -->
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -73,7 +73,7 @@
     
     <Style x:Key="IconButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-        <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
         <Setter Property="FontSize" Value="{StaticResource DefaultTextIconSize}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
@@ -85,14 +85,14 @@
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-                            <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
+                            <Setter Property="Background" Value="{StaticResource Transparent}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
-                            <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
-                            <!---<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />-->
+                            <Setter Property="Background" Value="{StaticResource Transparent}" />
+                            <!---<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />-->
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -111,14 +111,14 @@
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}" />
-                            <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}" />
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToBlackWhiteConverter}}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -129,7 +129,7 @@
     <Style x:Key="LinkButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
         <Setter Property="Margin" Value="4,6" />
         <Setter Property="TextColor" Value="{StaticResource Blue}" />
-        <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="FontSize" Value="Caption" />
     </Style>
 
@@ -147,7 +147,7 @@
         <Setter Property="WidthRequest" Value="50" />
         <Setter Property="HeightRequest" Value="50" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
 
     <Style x:Key="RoundedLongButtonStyle" TargetType="Button">
@@ -163,11 +163,11 @@
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
         <Setter Property="CornerRadius" Value="{OnIdiom Desktop=30, Tablet=30, Default=20}" />
         <Setter Property="WidthRequest" Value="{OnIdiom Desktop=350, Tablet=300, Phone=250, Default=250}" />
-        <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}"/>
+        <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="BorderWidth" Value="0" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="Button">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
+                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
                 <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="True" TargetType="Button">
@@ -175,7 +175,7 @@
             </Trigger>
             <DataTrigger
                 TargetType="Button"
-                Binding="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToLightForgroundConverter}}"
+                Binding="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToLightForgroundConverter}}"
                 Value="True"
                 >
                 <Setter Property="TextColor" Value="{StaticResource White}" />
@@ -184,7 +184,7 @@
     </Style>
 
     <Style x:Key="SetupButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundedLongButtonStyle}">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}"/>
     </Style>
 
@@ -196,7 +196,7 @@
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BorderWidth" Value="0" />
         <Setter Property="CornerRadius" Value="16" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
     
     <Style x:Key="SwipeTemplateButtonStyle" TargetType="Button">
@@ -206,12 +206,12 @@
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BorderWidth" Value="0" />
         <Setter Property="CornerRadius" Value="16" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
     <Style x:Key="RoundMaterialDesignIconButtonStyle" TargetType="Button">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-        <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
         <Setter Property="FontSize" Value="{StaticResource DefaultIconSize}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
@@ -223,7 +223,7 @@
         <!--<Setter Property="Text" Value="{StaticResource MaterialDesign_HandFrontRight}" />-->
         <Setter Property="Text" Value="{x:Static icons:MaterialIcons.HandFrontRight}" />
         <Setter Property="TextColor" Value="{StaticResource White}" />
-        <Setter Property="BackgroundColor" Value="{StaticResource Red}" />
+        <Setter Property="Background" Value="{StaticResource Red}" />
         <Setter Property="BorderColor" Value="{StaticResource Yellow}" />
         <Setter Property="BorderWidth" Value="3" />
         <Setter Property="HeightRequest" Value="{OnIdiom Tablet=70, Phone=50, Default=50}" />
@@ -240,6 +240,6 @@
                 Size="{StaticResource DefaultIconSize}"
                 />
         </Setter>
-        <Setter Property="BackgroundColor" Value="{StaticResource White}" />
+        <Setter Property="Background" Value="{StaticResource White}" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -5,21 +5,28 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
+    xmlns:localConcerters="clr-namespace:AndreasReitberger.Shared.Converters"
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons"
     >
-    <!---->
+    <!--
+    Important notes:
+    - Always set the `Background` or `BackgroundColor` property before setting the `TextColor` property!
+    - If using `BackgroundColor`. use the `Color...` converters, otherwise the `Brush...` converters
+    -->
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
-        <!--<ResourceDictionary Source="/Themes/SharedIcons.xaml" />-->
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <converters:ColorToLightForgroundConverter x:Key="ColorToLightForgroundConverter"  />
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
+    <localConcerters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
 
     <Style x:Key="DefaultButtonStyle" TargetType="Button">
-        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToBlackWhiteConverter}}" />
+        <!-- Set Background before setting the TextColor due to the Converter -->
         <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
+        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
+        <!--<Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=BackgroundColor, Converter={StaticResource ColorToBlackWhiteConverter}}" /> -->
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <Setter Property="FontSize" Value="{OnPlatform 
             Android={OnIdiom Phone=14, Default=18}, 
@@ -28,19 +35,19 @@
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
                     <!--
+                    <VisualState x:Name="Normal" />
+                    -->
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToBlackWhiteConverter}}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
                         </VisualState.Setters>
                     </VisualState>
-                    -->
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -72,8 +79,8 @@
     </Style>
     
     <Style x:Key="IconButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="Background" Value="{StaticResource Transparent}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
         <Setter Property="FontSize" Value="{StaticResource DefaultTextIconSize}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
@@ -84,15 +91,38 @@
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
                             <Setter Property="Background" Value="{StaticResource Transparent}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{StaticResource Transparent}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
+                            <!---<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />-->
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PrimaryIconButtonStyle" TargetType="Button" BasedOn="{StaticResource IconButtonStyle}">
+        <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
+        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
-                            <Setter Property="Background" Value="{StaticResource Transparent}" />
-                            <!---<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />-->
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -106,12 +136,14 @@
     </Style>
 
     <Style x:Key="PrimaryMaterialDesignIconButtonStyle" TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButtonStyle}">
+        <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
+        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource ColorToBlackWhiteConverter}}" />
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
                             <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
                         </VisualState.Setters>
                     </VisualState>
@@ -128,8 +160,8 @@
 
     <Style x:Key="LinkButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
         <Setter Property="Margin" Value="4,6" />
-        <Setter Property="TextColor" Value="{StaticResource Blue}" />
         <Setter Property="Background" Value="{StaticResource Transparent}" />
+        <Setter Property="TextColor" Value="{StaticResource Blue}" />
         <Setter Property="FontSize" Value="Caption" />
     </Style>
 
@@ -146,13 +178,14 @@
         <Setter Property="CornerRadius" Value="25" />
         <Setter Property="WidthRequest" Value="50" />
         <Setter Property="HeightRequest" Value="50" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
     </Style>
 
     <Style x:Key="RoundedLongButtonStyle" TargetType="Button">
         <Setter Property="Margin" Value="20" />
-        <Setter Property="TextColor" Value="{StaticResource Black}" />
+        <!--<Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>-->
+        <!--<Setter Property="TextColor" Value="{StaticResource Black}" />-->
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=18, Tablet=18, Phone=14, Default=14}" />-->
         <Setter Property="FontSize" Value="{OnPlatform 
@@ -163,8 +196,8 @@
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
         <Setter Property="CornerRadius" Value="{OnIdiom Desktop=30, Tablet=30, Default=20}" />
         <Setter Property="WidthRequest" Value="{OnIdiom Desktop=350, Tablet=300, Phone=250, Default=250}" />
-        <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="BorderWidth" Value="0" />
+        <!--
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="Button">
                 <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
@@ -181,6 +214,7 @@
                 <Setter Property="TextColor" Value="{StaticResource White}" />
             </DataTrigger>
         </Style.Triggers>
+        -->
     </Style>
 
     <Style x:Key="SetupButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundedLongButtonStyle}">
@@ -191,27 +225,27 @@
     <!--  Common style for swipe template content border control  -->
     <!-- Delete later due to wrong style naming -->
     <Style x:Key="SwipeTemplateBorderStyle" TargetType="Button">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="HeightRequest" Value="32" />
         <Setter Property="WidthRequest" Value="32" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BorderWidth" Value="0" />
         <Setter Property="CornerRadius" Value="16" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
     
     <Style x:Key="SwipeTemplateButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
         <Setter Property="HeightRequest" Value="32" />
         <Setter Property="WidthRequest" Value="32" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BorderWidth" Value="0" />
         <Setter Property="CornerRadius" Value="16" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
     <Style x:Key="RoundMaterialDesignIconButtonStyle" TargetType="Button">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="Background" Value="{StaticResource Transparent}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
         <Setter Property="FontSize" Value="{StaticResource DefaultIconSize}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
@@ -220,11 +254,10 @@
     </Style>
 
     <Style x:Key="RoundEmergencyStopIconButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundMaterialDesignIconButtonStyle}">
-        <!--<Setter Property="Text" Value="{StaticResource MaterialDesign_HandFrontRight}" />-->
-        <Setter Property="Text" Value="{x:Static icons:MaterialIcons.HandFrontRight}" />
-        <Setter Property="TextColor" Value="{StaticResource White}" />
         <Setter Property="Background" Value="{StaticResource Red}" />
         <Setter Property="BorderColor" Value="{StaticResource Yellow}" />
+        <Setter Property="TextColor" Value="{StaticResource White}" />
+        <Setter Property="Text" Value="{x:Static icons:MaterialIcons.HandFrontRight}" />
         <Setter Property="BorderWidth" Value="3" />
         <Setter Property="HeightRequest" Value="{OnIdiom Tablet=70, Phone=50, Default=50}" />
         <Setter Property="WidthRequest" Value="{OnIdiom Tablet=70, Phone=50, Default=50}" />
@@ -232,6 +265,7 @@
     </Style>
 
     <Style x:Key="GoogleLoginButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundedLongButtonStyle}">
+        <Setter Property="Background" Value="{StaticResource White}" />
         <Setter Property="ImageSource">
             <FontImageSource
                 FontFamily="{StaticResource MaterialDesignIcons}"
@@ -240,6 +274,5 @@
                 Size="{StaticResource DefaultIconSize}"
                 />
         </Setter>
-        <Setter Property="Background" Value="{StaticResource White}" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/CheckBox.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/CheckBox.xaml
@@ -13,14 +13,14 @@
     <Style x:Key="DefaultCheckBoxStyle" TargetType="CheckBox">
         <Setter Property="VerticalOptions" Value="Center" />
         <Setter Property="Color" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="Color" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Editor.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Editor.xaml
@@ -38,20 +38,20 @@
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Entry.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Entry.xaml
@@ -23,13 +23,13 @@
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -48,13 +48,13 @@
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Frame.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Frame.xaml
@@ -18,7 +18,7 @@
 
     <Style x:Key="ListViewItemFrameStyle" TargetType="Frame" BasedOn="{StaticResource DefaultFrameStyle}" >
         <Setter Property="BorderColor" Value="{StaticResource Transparent}"/>
-        <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Light_ItemTemplateBorder}, Dark={StaticResource Dark_ItemTemplateBorder}}" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Grid.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Grid.xaml
@@ -23,10 +23,10 @@
         </Setter>
         <Setter Property="IsAnimated" Value="False"/>
         <Setter Property="ColumnSpacing" Value="0"/>
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="control:TapAnimationGrid">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}"/>
+                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -45,25 +45,25 @@
         <Setter Property="ColumnSpacing" Value="0"/>
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="Grid">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}"/>
+                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <Style x:Key="DefaultSettingsGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
     </Style>
     <!--  Common style for WarningGrid  -->
     <Style x:Key="WarningGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
-        <Setter Property="BackgroundColor" Value="{StaticResource Yellow}" />
+        <Setter Property="Background" Value="{StaticResource Yellow}" />
     </Style>
     <!--  Common style for ErrorGrid  -->
     <Style x:Key="CriticalErrorGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
-        <Setter Property="BackgroundColor" Value="{StaticResource Red}" />
+        <Setter Property="Background" Value="{StaticResource Red}" />
     </Style>
     <!--  Common style for SettingsGrid  -->
     <Style x:Key="DefaultPanelGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
     </Style>
     <!--  Common style for ModalGrid  -->
     <Style x:Key="ModalPanelGridStyle" TargetType="Grid">

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
@@ -164,7 +164,7 @@
     <!--  Common style for swipe template content button control  -->
     <Style x:Key="SwipeTemplateButtonStyle" TargetType="Label">
         <!-- Check if needed 
-        <Setter Property="BackgroundColor" Value="Transparent" />-->
+        <Setter Property="Background" Value="Transparent" />-->
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
         <Setter Property="VerticalTextAlignment" Value="Center" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Page.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Page.xaml
@@ -12,7 +12,7 @@
     
     <Style TargetType="Page" ApplyToDerivedTypes="True">
         <Setter Property="Padding" Value="0"/>
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
     <Style TargetType="NavigationPage">
@@ -29,16 +29,16 @@
     </Style>
 
     <Style x:Key="DefaultPageStyle" TargetType="ContentPage">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
     <Style x:Key="ModalPageStyle" TargetType="ContentPage" BasedOn="{StaticResource DefaultPageStyle}">
         <Setter Property="Shell.PresentationMode" Value="ModalAnimated" />
         <Setter Property="ios:Page.ModalPresentationStyle" Value="{OnIdiom Tablet=Automatic, Default=FormSheet}" />
-        <!--<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />-->
+        <!--<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />-->
     </Style>
 
     <Style x:Key="SettingsPageStyle" TargetType="ContentPage" BasedOn="{StaticResource DefaultPageStyle}">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/RefreshView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/RefreshView.xaml
@@ -10,7 +10,7 @@
     
     <Style x:Key="DefaultRefreshViewStyle" TargetType="RefreshView">
         <Setter Property="RefreshColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={OnPlatform WinUI={StaticResource White}, Default={StaticResource Gray100}}, Dark={OnPlatform WinUI={StaticResource Black}, Default={StaticResource Gray900}}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={OnPlatform WinUI={StaticResource White}, Default={StaticResource Gray100}}, Dark={OnPlatform WinUI={StaticResource Black}, Default={StaticResource Gray900}}}" />
     </Style>
 
     <Style TargetType="RefreshView" BasedOn="{StaticResource DefaultRefreshViewStyle}" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shell.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shell.xaml
@@ -14,7 +14,7 @@
 
 
     <Style x:Key="BaseStyle" TargetType="Element">
-        <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="Shell.Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="Shell.ForegroundColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="Shell.TitleColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="Shell.DisabledColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
@@ -29,7 +29,7 @@
     <Style BasedOn="{StaticResource BaseStyle}" TargetType="ShellItem" ApplyToDerivedTypes="True" />
 
     <Style x:Key="DefaultShellStyle" TargetType="Shell">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}"/>
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}"/>
         <Setter Property="ForegroundColor" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="TitleColor" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="UnselectedColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}"/>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shell.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shell.xaml
@@ -14,6 +14,8 @@
 
 
     <Style x:Key="BaseStyle" TargetType="Element">
+        <!-- Must be BackgroundColor, otherwise TitleView is not set (at least on NET7) -->
+        <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="Shell.Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="Shell.ForegroundColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="Shell.TitleColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/StackLayout.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/StackLayout.xaml
@@ -9,7 +9,7 @@
     </ResourceDictionary.MergedDictionaries>
     
     <Style x:Key="StackLayoutHeaderStyle" TargetType="StackLayout">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
     <Style x:Key="ModalInputPageStackLayoutStyle" TargetType="StackLayout">
@@ -18,7 +18,7 @@
     </Style>
 
     <Style x:Key="VerticalStackLayoutHeaderStyle" TargetType="VerticalStackLayout">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
     <Style x:Key="VerticalModalInputPageStackLayoutStyle" TargetType="VerticalStackLayout">
@@ -27,7 +27,7 @@
     </Style>
 
     <Style x:Key="HorizontalStackLayoutHeaderStyle" TargetType="HorizontalStackLayout">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
     <Style x:Key="HorizontalModalInputPageStackLayoutStyle" TargetType="HorizontalStackLayout">

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml
@@ -46,7 +46,7 @@
                 StrokeShape="RoundRectangle 20"
                 StrokeThickness="0"
                 Margin="0,10"
-                BackgroundColor="{Binding PrimaryColor}"
+                Background="{Binding PrimaryColor}"
                 >
                 <Border.Shadow>
                     <Shadow 
@@ -74,7 +74,7 @@
                             StrokeShape="RoundRectangle 10"
                             StrokeThickness="0"
                             Margin="20,10"
-                            BackgroundColor="{Binding PrimaryLigtherColor}"
+                            Background="{Binding PrimaryLigtherColor}"
                             >
                             <Label
                                 Text="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToStringConverter}}"
@@ -89,7 +89,7 @@
                             StrokeShape="RoundRectangle 10"
                             StrokeThickness="0"
                             Margin="20,10"
-                            BackgroundColor="{Binding PrimaryDarkerColor}"
+                            Background="{Binding PrimaryDarkerColor}"
                             >
                             <Label
                                 Text="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToStringConverter}}"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
@@ -20,11 +20,11 @@
             RowSpacing="4"
             RowDefinitions="*,64,Auto"
             >
-            <!-- BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" -->
+            <!-- Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" -->
             <Frame
                 Margin="20,16"
                 BorderColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
-                BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                 >
                 <Image
                     Margin="4"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -24,7 +24,7 @@
                 <!-- Check icon -->
                 <Border
                     Style="{StaticResource ProfileBorderStyle}"
-                    BackgroundColor="{StaticResource LightGreen}"
+                    Background="{StaticResource LightGreen}"
                     Margin="0"
                     >
                     <Label 
@@ -171,7 +171,7 @@
             <Grid 
                 Padding="2"
                 Margin="1"
-                BackgroundColor="{DynamicResource PrimaryColor}"
+                Background="{DynamicResource PrimaryColor}"
                 ColumnDefinitions="48,*"
                 >
                 <Grid.RowDefinitions>
@@ -227,7 +227,7 @@
                     Text="{Binding Changelog}"
                     />
                 <Border 
-                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
+                    Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
                     Style="{StaticResource ProfileBorderStyle}"
                     Grid.Column="1"
                     VerticalOptions="Center"
@@ -259,7 +259,7 @@
                     Text="{Binding Changelog}"
                     />
                 <Border 
-                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
+                    Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
                     Style="{StaticResource ProfileBorderStyle}"
                     Grid.Column="1"
                     VerticalOptions="Center"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ShellItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ShellItemTemplates.xaml
@@ -28,13 +28,13 @@
                     <VisualStateGroup x:Name="CommonStates">
                         <VisualState x:Name="Normal">
                             <VisualState.Setters>
-                                <Setter Property="BackgroundColor" Value="Transparent" />
+                                <Setter Property="Background" Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                         <VisualState x:Name="Selected">
                             <VisualState.Setters>
                                 <Setter
-                                    Property="BackgroundColor"
+                                    Property="Background"
                                     Value="{OnPlatform WinUI=Transparent, Default={AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}}"
                                     />
                             </VisualState.Setters>
@@ -42,7 +42,7 @@
                         <VisualState x:Name="Disabled">
                             <VisualState.Setters>
                                 <Setter
-                                    Property="BackgroundColor"
+                                    Property="Background"
                                     Value="{OnPlatform WinUI=Transparent, Default={AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray500}}}"
                                     />
                             </VisualState.Setters>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\common.props" />
 
 	<PropertyGroup>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -52,7 +52,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.15" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.16" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -92,6 +92,10 @@
 	    <SubType>Code</SubType>
 	    <DependentUpon>SharedFonts.xaml</DependentUpon>
 	  </Compile>
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 	</ItemGroup>
 
 	<!--


### PR DESCRIPTION
It seems that the `BackgroundColor` property is an outdated way in order to set the background color.
Instead, the way should be to use the newer `Background` property instead.

This PR will update all `Controls` to set the `Background` property instead of the `BackgroundColor` property.
Also some minor style fixes have been made while debugging the changes.

In order to finally merge this PR, I need to first release the new core library changes (due to new `Brush` converters).

- [x] https://github.com/AndreasReitberger/SharedMauiCoreLibrary/pull/85

Fixed #279 