### PR TITLE
Migrate to `net8`

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.2.0-net8preview1</Version>
+        <Version>1.2.0</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/SharedMauiXamlStyles</PackageProjectUrl>

--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.1.5</Version>
+        <Version>1.2.0-net8preview1</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/SharedMauiXamlStyles</PackageProjectUrl>

--- a/common.props
+++ b/common.props
@@ -29,6 +29,9 @@
    </ItemGroup>
 -->
   <ItemGroup>
+	<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+	<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.2.23479.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/MauiProgram.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/MauiProgram.cs
@@ -25,7 +25,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp
                 });
 
 #if DEBUG
-		builder.Logging.AddDebug();
+		    builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -49,8 +49,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-preview.7.23375.6" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.1.23419.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -82,4 +82,8 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+	</ItemGroup>
+
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\common.props" />
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>SharedMauiXamlStylesLibrary.SampleApp</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -49,7 +49,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-preview.7.23375.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -49,11 +49,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.1.23419.4" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary.Syncfusion\SharedMauiXamlStylesLibrary.Syncfusion.csproj" />
 	</ItemGroup>
 

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
@@ -55,5 +55,4 @@
     </Style>
 
     <Style TargetType="inputLayout:SfChipGroup" BasedOn="{StaticResource DefaultChipGroupStyle}"/>
-    <<!-- -->
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
@@ -14,8 +14,9 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Docs: https://help.syncfusion.com/maui/chips -->
+    <!-- MissingFieldException: Field not found: 'Syncfusion.Maui.Core.SfChip.FontSizeProperty  on Net8? -->
     <Style x:Key="DefaultChipStyle" TargetType="inputLayout:SfChip">
-        <Setter Property="FontSize" Value="{OnIdiom Tablet=14, Default=12}" />
+        <Setter Property="FontSize" Value="{OnIdiom Tablet=14, Default=12}" /> 
         <Setter Property="FontFamily" Value="{StaticResource MontserratBold}" />
         <Setter Property="StrokeThickness" Value="0"/>
         <Setter Property="Padding" Value="2"/>
@@ -27,6 +28,9 @@
         <Setter Property="ShowSelectionIndicator" Value="False"/>
         <Setter Property="SelectionIndicatorColor" Value="{StaticResource Transparent}" />
     </Style>
+    
+    <Style TargetType="inputLayout:SfChip" BasedOn="{StaticResource DefaultChipStyle}"/>
+    
     
     <Style x:Key="DefaultChipGroupStyle" TargetType="inputLayout:SfChipGroup">
         <Setter Property="SelectionIndicatorColor" Value="{DynamicResource PrimaryColor}"/>
@@ -50,6 +54,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="inputLayout:SfChip" BasedOn="{StaticResource DefaultChipStyle}"/>
     <Style TargetType="inputLayout:SfChipGroup" BasedOn="{StaticResource DefaultChipGroupStyle}"/>
+    <<!-- -->
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
@@ -24,7 +24,7 @@
         <Setter Property="Margin" Value="4,2"/>
         <!--<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />-->
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" /><!---->
-        <!--
+       <!--
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfListView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfListView.xaml
@@ -16,7 +16,7 @@
         <Setter Property="SelectionBackground" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="listView:SfListView">
-                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray600}}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTabView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTabView.xaml
@@ -14,9 +14,11 @@
     </ResourceDictionary.MergedDictionaries>
     
     <Style x:Key="DefaultSfTabViewStyle" TargetType="tabView:SfTabView">
-        <Setter Property="IndicatorBackground" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="IndicatorPlacement" Value="Top"/>
         <Setter Property="TabBarBackground" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
+        <!-- Seems to cause troubles if set in style already. So rather set in the app later -->
+        <!--<Setter Property="IndicatorBackground" Value="{DynamicResource PrimaryColor}"/>-->
+        <Setter Property="IndicatorBackground" Value="{StaticResource PrimaryColor}"/>
     </Style>
 
     <!-- Workaround for wrong style name-->

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/DefaultTheme.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/DefaultTheme.xaml
@@ -14,5 +14,6 @@
         <!-- Templates must come for styles! -->
         <ResourceDictionary Source="/Resources/Themes/SharedTemplates.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedStyles.xaml" />
+        <ResourceDictionary Source="/Resources/Themes/SyncfusionTheme.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -213,10 +213,10 @@
             </Grid>
     </DataTemplate>
 
-    <DataTemplate x:Key="DuplicateEditDeleteGestureSwipeTemplate">
+    <DataTemplate x:Key="DeleteEditViewGestureSwipeTemplate">
         <Grid
-                ColumnDefinitions="*,*,*"
-                >
+            ColumnDefinitions="*,*,*"
+            >
             <Label
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
@@ -253,15 +253,15 @@
                 </Label.GestureRecognizers>
             </Label>
             <Label
-                    Grid.Column="2"
-                    Style="{StaticResource IconLabelStyle}"
-                    Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
-                    TextColor="{StaticResource White}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center"
-                    Margin="0"
-                    Background="{StaticResource Blue}"
-                    >
+                Grid.Column="2"
+                Style="{StaticResource IconLabelStyle}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Viewed}"
+                TextColor="{StaticResource White}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                Background="{StaticResource Blue}"
+                >
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer
                             NumberOfTapsRequired="1"
@@ -447,7 +447,7 @@
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    Background="{StaticResource Green}"
+                    Background="{StaticResource Red}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -20,134 +20,126 @@
     <!-- Single Swipe Templates -->
 
     <DataTemplate x:Key="DeleteGestureSwipeTemplate">
-        <ViewCell>
+        <Label
+            Style="{StaticResource IconLabelStyle}"
+            Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
+            TextColor="{StaticResource White}"
+            VerticalTextAlignment="Center"
+            HorizontalTextAlignment="Center"
+            Background="{StaticResource Red}"
+            Margin="0"
+            >
+            <Label.GestureRecognizers>
+                <TapGestureRecognizer
+                    NumberOfTapsRequired="1"
+                    Command="{Binding BindingContext.DeleteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                    CommandParameter="{Binding .}"
+                    />
+            </Label.GestureRecognizers>
+        </Label>
+    </DataTemplate>
+
+    <DataTemplate x:Key="EditGestureSwipeTemplate">
+        <Grid
+            Background="{StaticResource Green}"
+            >
             <Label
                 Style="{StaticResource IconLabelStyle}"
-                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                 TextColor="{StaticResource White}"
+                Background="{StaticResource Green}"
                 VerticalTextAlignment="Center"
                 HorizontalTextAlignment="Center"
-                Background="{StaticResource Red}"
                 Margin="0"
                 >
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer
                         NumberOfTapsRequired="1"
-                        Command="{Binding BindingContext.DeleteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                        Command="{Binding BindingContext.EditItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                         CommandParameter="{Binding .}"
                         />
                 </Label.GestureRecognizers>
             </Label>
-        </ViewCell>
-    </DataTemplate>
-
-    <DataTemplate x:Key="EditGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
-                Background="{StaticResource Green}"
-                >
-                <Label
-                    Style="{StaticResource IconLabelStyle}"
-                    Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
-                    TextColor="{StaticResource White}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center"
-                    Margin="0"
-                    >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
-                            NumberOfTapsRequired="1"
-                            Command="{Binding BindingContext.EditItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
-                            CommandParameter="{Binding .}"
-                            />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="ViewGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
-                Background="{StaticResource Blue}"
-                >
-                <Label
-                    Style="{StaticResource IconLabelStyle}"
-                    Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
-                    TextColor="{StaticResource White}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center"
-                    >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
-                            NumberOfTapsRequired="1"
-                            Command="{Binding BindingContext.ViewItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
-                            CommandParameter="{Binding .}"
-                            />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
-    </DataTemplate>
-
-    <DataTemplate x:Key="PrintGestureSwipeTemplate">
-        <ViewCell>
+        <Grid
+            Background="{StaticResource Blue}"
+            >
             <Label
-                Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
-                Text="{x:Static icons:MaterialIcons.Printer3dNozzleOutline}"
+                Style="{StaticResource IconLabelStyle}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
                 TextColor="{StaticResource White}"
+                Background="{StaticResource Blue}"
                 VerticalTextAlignment="Center"
                 HorizontalTextAlignment="Center"
-                Background="{StaticResource Green}"
                 Margin="0"
                 >
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding BindingContext.ViewItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                        CommandParameter="{Binding .}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="PrintGestureSwipeTemplate">
+        <Label
+            Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+            Text="{x:Static icons:MaterialIcons.Printer3dNozzleOutline}"
+            TextColor="{StaticResource White}"
+            VerticalTextAlignment="Center"
+            HorizontalTextAlignment="Center"
+            Background="{StaticResource Green}"
+            Margin="0"
+            >
+            <Label.GestureRecognizers>
+                <TapGestureRecognizer
                         NumberOfTapsRequired="1"
                         Command="{Binding BindingContext.PrintItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                         CommandParameter="{Binding .}"
                         />
-                </Label.GestureRecognizers>
-            </Label>
-        </ViewCell>
+            </Label.GestureRecognizers>
+        </Label>
     </DataTemplate>
 
     <DataTemplate x:Key="ExecuteGestureSwipeTemplate">
-        <ViewCell>
-            <Label
-                Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
-                Text="{x:Static icons:MaterialIcons.RunFast}"
-                TextColor="{StaticResource White}"
-                VerticalTextAlignment="Center"
-                HorizontalTextAlignment="Center"
-                Background="{StaticResource Orange}"
-                Margin="0"
-                >
-                <Label.GestureRecognizers>
-                    <TapGestureRecognizer
-                        NumberOfTapsRequired="1"
-                        Command="{Binding BindingContext.ExecuteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
-                        CommandParameter="{Binding .}"
-                        />
-                </Label.GestureRecognizers>
-            </Label>
-        </ViewCell>
+        <Label
+            Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+            Text="{x:Static icons:MaterialIcons.RunFast}"
+            TextColor="{StaticResource White}"
+            VerticalTextAlignment="Center"
+            HorizontalTextAlignment="Center"
+            Background="{StaticResource Orange}"
+            Margin="0"
+            >
+            <Label.GestureRecognizers>
+                <TapGestureRecognizer
+                    NumberOfTapsRequired="1"
+                    Command="{Binding BindingContext.ExecuteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                    CommandParameter="{Binding .}"
+                    />
+            </Label.GestureRecognizers>
+        </Label>
     </DataTemplate>
 
     <!-- Double Swipe Templates -->
     <DataTemplate x:Key="EditDeleteGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
+        <Grid
                 ColumnDefinitions="*,*"
                 >
                 <Label
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                     TextColor="{StaticResource White}"
+                    Background="{StaticResource Red}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    Background="{StaticResource Red}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -162,10 +154,10 @@
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                     TextColor="{StaticResource White}"
+                    Background="{StaticResource Green}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Center"
                     Margin="0"
-                    Background="{StaticResource Green}"
                     >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer
@@ -176,12 +168,10 @@
                     </Label.GestureRecognizers>
                 </Label>
             </Grid>
-        </ViewCell>
     </DataTemplate>
 
     <DataTemplate x:Key="EditExportGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
+        <Grid
                 ColumnDefinitions="*,*"
                 >
                 <Label
@@ -221,15 +211,13 @@
                     </Label.GestureRecognizers>
                 </Label>
             </Grid>
-        </ViewCell>
     </DataTemplate>
 
     <DataTemplate x:Key="DuplicateEditDeleteGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
+        <Grid
                 ColumnDefinitions="*,*,*"
                 >
-                <Label
+            <Label
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Viewed}"
                     TextColor="{StaticResource White}"
@@ -238,15 +226,15 @@
                     Margin="0"
                     Background="{StaticResource Blue}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.DuplicateItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
                     Grid.Column="1"
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
@@ -256,15 +244,15 @@
                     Margin="0"
                     Background="{StaticResource Green}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.EditItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
                     Grid.Column="2"
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
@@ -274,24 +262,22 @@
                     Margin="0"
                     Background="{StaticResource Green}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.DeleteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
+                </Label.GestureRecognizers>
+            </Label>
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="ViewDeleteGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
+        <Grid
                 ColumnDefinitions="*,*"
                 >
-                <Label
+            <Label
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                     TextColor="{StaticResource White}"
@@ -300,15 +286,15 @@
                     Margin="0"
                     Background="{StaticResource Red}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.DeleteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
                     Grid.Column="1"
                     Style="{StaticResource IconLabelStyle}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
@@ -318,24 +304,22 @@
                     Margin="0"
                     Background="{StaticResource Blue}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.ViewItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
+                </Label.GestureRecognizers>
+            </Label>
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="PrintViewGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
+        <Grid
                 ColumnDefinitions="*,*"
                 >
-                <Label
+            <Label
                     Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
                     Text="{x:Static icons:MaterialIcons.Printer3dNozzleOutline}"
                     TextColor="{StaticResource White}"
@@ -344,15 +328,15 @@
                     Background="{StaticResource Green}"
                     Margin="0"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.PrintItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
                     Grid.Column="1"
                     Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
                     Text="{x:Static icons:MaterialIcons.EyeOutline}"
@@ -362,24 +346,22 @@
                     Margin="0"
                     Background="{StaticResource Blue}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.ViewItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
+                </Label.GestureRecognizers>
+            </Label>
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="ExecuteEditGestureSwipeTemplate">
-        <ViewCell>
-            <Grid
+        <Grid
                 ColumnDefinitions="*,*"
                 >
-                <Label
+            <Label
                     Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
                     Text="{x:Static icons:MaterialIcons.RunFast}"
                     TextColor="{StaticResource White}"
@@ -388,15 +370,15 @@
                     Background="{StaticResource Orange}"
                     Margin="0"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.ExecuteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
                     Grid.Column="1"
                     Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
                     Text="{x:Static icons:MaterialIcons.PencilOutline}"
@@ -406,15 +388,14 @@
                     Margin="0"
                     Background="{StaticResource Green}"
                     >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
                             NumberOfTapsRequired="1"
                             Command="{Binding BindingContext.EditItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
                             CommandParameter="{Binding .}"
                             />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
+                </Label.GestureRecognizers>
+            </Label>
+        </Grid>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/SyncfusionTheme.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/SyncfusionTheme.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.SyncfusionTheme"
+    
+    xmlns:shared="clr-namespace:AndreasReitberger.Shared;assembly=SharedMauiXamlStylesLibrary"
+    >
+    <!--
+    <Color x:Key="SfComboBoxDropdownBackground"></Color>
+    <Color x:Key="SfComboBoxNormalDropdownItemsTextColor">#B02F35</Color>
+    -->
+</ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/SyncfusionTheme.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/SyncfusionTheme.xaml.cs
@@ -1,0 +1,12 @@
+namespace AndreasReitberger.Shared.Syncfusion;
+
+/// <summary>
+/// This theme just holds the fonts and color resources to overwrite some Syncfusion colors / styles.
+/// </summary>
+public partial class SyncfusionTheme
+{
+    public SyncfusionTheme()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -108,6 +108,10 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+	</ItemGroup>
+
 	<!-- Maui Samples styles do not have the Compile attribute, maybe this causes problems for Intelisense.
 	<ItemGroup>
 	  <MauiXaml Update="Resources\Themes\Controls\Core\EnhancedListView.xaml">

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -53,8 +53,8 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
-	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	  <PackageReference Include="Syncfusion.Maui.Charts" Version="23.1.40" />
 	  <PackageReference Include="Syncfusion.Maui.Core" Version="23.1.40" />
 	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="23.1.40" />
@@ -65,6 +65,7 @@
 	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="23.1.40" />
 	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="23.1.40" />
 	  <PackageReference Include="Syncfusion.Maui.TabView" Version="23.1.40" />
+	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -53,8 +53,6 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	  <PackageReference Include="Syncfusion.Maui.Charts" Version="23.1.42" />
 	  <PackageReference Include="Syncfusion.Maui.Core" Version="23.1.42" />
 	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="23.1.42" />

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -2,8 +2,8 @@
  <Import Project="..\..\common.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -53,6 +53,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
 	  <PackageReference Include="Syncfusion.Maui.Charts" Version="22.2.10" />
 	  <PackageReference Include="Syncfusion.Maui.Core" Version="22.2.10" />
@@ -67,6 +68,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Update="Resources\Themes\SyncfusionTheme.xaml.cs">
+	    <SubType>Code</SubType>
+	    <DependentUpon>SyncfusionTheme.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Resources\Themes\MinimalisticTheme.xaml.cs">
 	    <DependentUpon>MinimalisticTheme.xaml</DependentUpon>
 	  </Compile>
@@ -96,6 +101,12 @@
 	    <SubType>Code</SubType>
 	    <DependentUpon>SharedFonts.xaml</DependentUpon>
 	  </Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <MauiXaml Update="Resources\Themes\SyncfusionTheme.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	</ItemGroup>
 
 	<!-- Maui Samples styles do not have the Compile attribute, maybe this causes problems for Intelisense.

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
 	  <PackageReference Include="Syncfusion.Maui.Charts" Version="23.1.36" />
 	  <PackageReference Include="Syncfusion.Maui.Core" Version="23.1.36" />

--- a/src/SharedMauiXamlStylesLibrary/Interfaces/IThemeManager.cs
+++ b/src/SharedMauiXamlStylesLibrary/Interfaces/IThemeManager.cs
@@ -7,13 +7,13 @@ namespace AndreasReitberger.Shared.Interfaces
     public interface IThemeManager
     {
         #region Properties
-        AppTheme Theme { get; }
+        public AppTheme Theme { get; }
         #endregion
 
         #region Methods
         //ResourceDictionary GetThemeResources(AppTheme theme);
-        void ApplyTheme(AppTheme theme, Application app);
-        void UpdatePrimaryThemeColor(ThemeColorInfo theme, Application app);
+        public void ApplyTheme(AppTheme theme, Application app);
+        public void UpdatePrimaryThemeColor(ThemeColorInfo theme, Application app);
         #endregion
     }
 }

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Border.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Border.xaml
@@ -34,7 +34,18 @@
             </Setter.Value>
         </Setter>
         <Setter Property="StrokeThickness" Value="1"/>
-        <Setter Property="Shadow" Value="{StaticResource CardViewShadowStyle}"/>
+        <!-- Causes: Microsoft.Maui.Controls.BindableObject: Warning: Cannot convert Microsoft.Maui.Controls.Style to type 'Microsoft.Maui.Controls.Shadow' -->
+        <!--<Setter Property="Shadow" Value="{StaticResource CardViewShadowStyle}"/>-->
+        <Setter Property="Shadow">
+            <Setter.Value>
+                <Shadow 
+                    Radius="40" 
+                    Opacity="0.8" 
+                    Brush="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}"
+                    Offset="20,20"
+                    />
+            </Setter.Value>
+        </Setter>
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"/>
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"/>
     </Style>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shadow.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shadow.xaml
@@ -7,6 +7,9 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
+
+    <!-- Causes: Microsoft.Maui.Controls.BindableObject: Warning: Cannot convert Microsoft.Maui.Controls.Style to type 'Microsoft.Maui.Controls.Shadow' -->
+    <!-- Use directly, not as StaticResource
     <Style x:Key="DefaultShadowStyle" TargetType="Shadow">
         <Setter Property="Radius" Value="15" />
         <Setter Property="Opacity" Value="0.5" />
@@ -22,4 +25,5 @@
         <Setter Property="Brush" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
         <Setter Property="Offset" Value="20,20" />
     </Style>
+    -->
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -7,6 +7,7 @@
     
     xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
     xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
+    xmlns:theme="clr-namespace:AndreasReitberger.Shared.Core.Theme;assembly=SharedMauiCoreLibrary"
     xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"  
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"   
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons"
@@ -276,4 +277,123 @@
         </ViewCell>
     </DataTemplate>
 
+    <!-- Theme -->
+    <DataTemplate x:Key="DefaultThemeColorInfoListViewItemTemplate" x:DataType="theme:ThemeColorInfo">
+        <Grid>
+            <Border
+                StrokeShape="RoundRectangle 10"
+                StrokeThickness="0"
+                Margin="5,10"
+                BackgroundColor="{Binding PrimaryColor}"
+                >
+                <Border.Shadow>
+                    <Shadow 
+                        Opacity="0.5"
+                        Radius="12"
+                        Offset="0, 12"
+                        />
+                </Border.Shadow>
+                <Grid
+                    RowDefinitions="Auto,*"
+                    >
+                    <Label
+                        Text="{Binding ThemeName}"
+                        Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                        TextColor="{Binding PrimaryColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                        VerticalTextAlignment="Center"
+                        HorizontalTextAlignment="Center"
+                        Margin="10,20"
+                        />
+                    <!--
+                <VerticalStackLayout
+                    Grid.Row="1"
+                    >
+                    <Border
+                        StrokeShape="RoundRectangle 10"
+                        StrokeThickness="0"
+                        Margin="20,10"
+                        BackgroundColor="{Binding PrimaryLigtherColor}"
+                        >
+                        <Label
+                            Text="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToStringConverter}}"
+                            Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                            TextColor="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                            VerticalTextAlignment="Center"
+                            HorizontalTextAlignment="Center"
+                            Margin="10,20"
+                            />
+                    </Border>
+                    <Border
+                        StrokeShape="RoundRectangle 10"
+                        StrokeThickness="0"
+                        Margin="20,10"
+                        BackgroundColor="{Binding PrimaryDarkerColor}"
+                        >
+                        <Label
+                            Text="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToStringConverter}}"
+                            Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                            TextColor="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                            VerticalTextAlignment="Center"
+                            HorizontalTextAlignment="Center"
+                            Margin="10,20"
+                            />
+                    </Border>
+                </VerticalStackLayout>
+                -->
+                </Grid>
+            </Border>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="ColorInfoListViewItemTemplate" x:DataType="theme:ColorInfo">
+        <Grid>
+            <Border
+                StrokeShape="RoundRectangle 5"
+                StrokeThickness="0"
+                Margin="5,10"
+                BackgroundColor="{Binding Color}"
+                >
+                <Border.Shadow>
+                    <Shadow 
+                        Opacity="0.5"
+                        Radius="12"
+                        Offset="0, 12"
+                        />
+                </Border.Shadow>
+                <Grid
+                    ColumnDefinitions="2*,*,*,*"
+                    >
+                    <Label
+                        Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                        TextColor="{Binding Color, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                        VerticalTextAlignment="Center"
+                        HorizontalTextAlignment="Center"
+                        Margin="10,20"
+                        Text="{Binding Name}"
+                        />
+
+                    <VerticalStackLayout
+                        Grid.Column="1"
+                        >
+                        <Label
+                            Text="{Binding Name}"
+                            Style="{StaticResource SmallLabelStyle}"
+                            TextColor="{Binding Color, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                            VerticalTextAlignment="Center"
+                            HorizontalTextAlignment="Center"
+                            Margin="10,8"
+                            />
+                        <Label
+                            Text="{Binding Color, Converter={StaticResource ColorToStringConverter}}"
+                            Style="{StaticResource MediumLabelStyle}"
+                            TextColor="{Binding Color, Converter={StaticResource ColorToBlackWhiteConverter}}"
+                            VerticalTextAlignment="Center"
+                            HorizontalTextAlignment="Center"
+                            Margin="10,8"
+                            />
+                    </VerticalStackLayout>
+                </Grid>
+            </Border>
+        </Grid>
+    </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedStyles.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedStyles.xaml
@@ -5,7 +5,7 @@
     x:Class="AndreasReitberger.Shared.Styles"
     >
     <ResourceDictionary.MergedDictionaries>
-        <!-- Must come for Boarder! -->
+        <!-- Must come for Border! -->
         <ResourceDictionary Source="/Resources/Themes/Controls/Shadow.xaml" />
         
         <ResourceDictionary Source="/Resources/Themes/Controls/ActivityIndicator.xaml" />

--- a/src/SharedMauiXamlStylesLibrary/SharedFonts.cs
+++ b/src/SharedMauiXamlStylesLibrary/SharedFonts.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace AndreasReitberger.Shared
+﻿namespace AndreasReitberger.Shared
 {
     public class SharedFonts
     {

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -53,9 +53,6 @@
 
 	<ItemGroup>
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.16" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.2.9373" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -2,8 +2,8 @@
 	<Import Project="..\..\common.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -52,6 +52,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+      <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.15" />
 	</ItemGroup>
 	
@@ -93,133 +94,4 @@
 	    <DependentUpon>SharedFonts.xaml</DependentUpon>
 	  </Compile>
 	</ItemGroup>
-
-	<!--
-	<ItemGroup>
-	  <MauiXaml Update="Resources\Themes\Controls\Border.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\DatePicker.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\RadioButton.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\ProgressBar.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Picker.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\ListView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\IndicatorView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\SwipeItem.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Slider.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Shadow.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\SearchHandler.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\SearchBar.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Shell.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\ActivityIndicator.xaml">
-	    <SubType>Designer</SubType>
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Page.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\TimePicker.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Switch.xaml">
-	    <SubType>Designer</SubType>
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\CheckBox.xaml">
-	    <SubType>Designer</SubType>
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Button.xaml">
-	    <SubType>Designer</SubType>
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\BoxView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Editor.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Entry.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Frame.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Grid.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\Label.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\RefreshView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\Controls\StackLayout.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\ItemTemplates\CarouselViewItemTemplates.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\MinimalisticTheme.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\SharedTemplates.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\SharedStyles.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\ItemTemplates\ShellItemTemplates.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\ItemTemplates\ListViewGroupHeaderTemplates.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\ItemTemplates\ListViewHeaderTemplates.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\ItemTemplates\GeneralItemTemplates.xaml">
-	    <SubType>Designer</SubType>
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\ItemTemplates\ListViewItemTemplates.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\SharedColors.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\SharedFonts.xaml">
-	    <SubType>Designer</SubType>
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Themes\DefaultTheme.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
-	-->
-
 </Project>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -52,7 +52,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.16" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.0" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -92,5 +92,9 @@
 	    <SubType>Code</SubType>
 	    <DependentUpon>SharedFonts.xaml</DependentUpon>
 	  </Compile>
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -55,7 +55,7 @@
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.16" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.1.23419.4" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.2.9373" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -53,7 +53,9 @@
 
 	<ItemGroup>
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.0.16" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rc.1.23419.4" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/restore.bat
+++ b/src/restore.bat
@@ -1,0 +1,6 @@
+echo off
+
+echo "Restore..."
+dotnet restore
+
+pause


### PR DESCRIPTION
This PR migrates the style libraries to use `net8` instead of `net7`. This will be merged once `net8` is GA.

Fixed #248 