### PR TITLE
Added `UpDownButtonColor` to `SfNumericEntry` styles

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.SampleApp/AppShell.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/AppShell.xaml
@@ -27,6 +27,11 @@
         Route="ButtonsPage" />
 
     <ShellContent
+        Title="Entry"
+        ContentTemplate="{DataTemplate views:EntryPage}"
+        Route="EntryPage" />
+
+    <ShellContent
         Title="TabView"
         ContentTemplate="{DataTemplate views:TabViewPage}"
         Route="TabViewPage" />

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Hosting/AppHostBuilderExtensions.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Hosting/AppHostBuilderExtensions.cs
@@ -33,6 +33,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.Hosting
             // Main view models
             builder.Services.AddSingleton<AppShellViewModel>();
             builder.Services.AddSingleton<LabesPageViewModel>();
+            builder.Services.AddSingleton<EntryPageViewModel>();
             builder.Services.AddSingleton<ButtonsPageViewModel>();
             builder.Services.AddSingleton<TabViewPageViewModel>();
             return builder;
@@ -44,6 +45,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.Hosting
             builder.Services.AddSingleton<AppShell>();
             // Main view models
             builder.Services.AddSingleton<ButtonsPage>();
+            builder.Services.AddSingleton<EntryPage>();
             builder.Services.AddSingleton<LabelsPage>();
             builder.Services.AddSingleton<TabViewPage>();
             return builder;

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\common.props" />
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
@@ -53,6 +53,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Update="Views\EntryPage.xaml.cs">
+	    <DependentUpon>EntryPage.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Views\TabViewPage.xaml.cs">
 	    <DependentUpon>TabViewPage.xaml</DependentUpon>
 	  </Compile>
@@ -71,6 +74,9 @@
 	  <MauiXaml Update="Themes\DefaultTheme.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\EntryPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\TabViewPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
@@ -81,9 +87,4 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-	</ItemGroup>
-
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/ViewModels/EntryPageViewModel.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/ViewModels/EntryPageViewModel.cs
@@ -1,0 +1,29 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SharedMauiXamlStylesLibrary.SampleApp.ViewModels
+{
+    public partial class EntryPageViewModel : BaseViewModel
+    {
+
+        #region Properties
+
+        [ObservableProperty]
+        string sampleText = "This is just a sample text";
+
+        [ObservableProperty]
+        double sampleValue = 2;
+
+        #endregion
+
+        #region Constructor, LoadSettings
+
+        public EntryPageViewModel(IDispatcher dispatcher, IServiceProvider provider) : base(dispatcher, provider)
+        {
+            Dispatcher = dispatcher;
+            UpdateVersionBuild();
+        }
+
+        #endregion
+
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/EntryPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/EntryPage.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="SharedMauiXamlStylesLibrary.SampleApp.Views.EntryPage"
+    
+    xmlns:viewModels="clr-namespace:SharedMauiXamlStylesLibrary.SampleApp.ViewModels"
+    
+    xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
+    
+    xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons;assembly=SharedMauiXamlStylesLibrary.Syncfusion"
+    
+    xmlns:editors="clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs"
+    
+    Title="ButtonsPage"
+    Style="{StaticResource DefaultPageStyle}"
+    x:DataType="viewModels:EntryPageViewModel"   
+    >
+    <ContentPage.Resources>
+        <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
+    </ContentPage.Resources>
+    <ScrollView>
+        <VerticalStackLayout>
+            <Label 
+                Margin="2,16"
+                Text="Entries"
+                VerticalTextAlignment="Center" 
+                HorizontalTextAlignment="Center"
+                Style="{StaticResource LabelStyle}"
+                />
+            
+            <Entry 
+                Margin="8,16"
+                Text="{Binding SampleText}"
+                />
+            
+            <editors:SfNumericEntry 
+                Margin="8,16"
+                Value="{Binding SampleValue}"
+                Style="{StaticResource DefaultSfNumericEntryStyle}"
+                Background="Green"
+                />
+            
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/EntryPage.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/EntryPage.xaml.cs
@@ -1,0 +1,12 @@
+using SharedMauiXamlStylesLibrary.SampleApp.ViewModels;
+
+namespace SharedMauiXamlStylesLibrary.SampleApp.Views;
+
+public partial class EntryPage : ContentPage
+{
+    public EntryPage(EntryPageViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfNumericEntry.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfNumericEntry.xaml
@@ -18,6 +18,7 @@
         <Setter Property="Minimum" Value="0" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+        <Setter Property="UpDownButtonColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="ClearButtonColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="FontSize" Value="Default" />
         <Setter Property="IsEditable" Value="True" />

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -54,17 +54,17 @@
 	
 	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Core" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Expander" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.ListView" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Picker" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="23.2.6" />
-	  <PackageReference Include="Syncfusion.Maui.TabView" Version="23.2.6" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Core" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Expander" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.ListView" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Picker" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="24.1.41" />
+	  <PackageReference Include="Syncfusion.Maui.TabView" Version="24.1.41" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR adds the `UpDownButtonColor` to the style files for the `SfNumericEntry` control. Syncfusion has implemented this in their latest release.

Fixed #175