### PR TITLE
Renamed all styles to fit new syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,200 +129,198 @@ https://github.com/AndreasReitberger/SharedMauiXamlStyles/issues/43
 
 ## ActivityIndicator
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultActivityIndicator               | ActivityIndicator   | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.ActivityIndicator.Default         | ActivityIndicator   | Core      |
 
 ## Border
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| ProfileBorderStyle                     | Border              | Core      |
-| CardViewBorderStyle                    | Border              | Core      |
-| PanelCardViewBorderStyle               | Border              | Core      |
-| MinimalPanelCardViewBorderStyle        | Border              | Core      |
-| BrightMinimalPanelCardViewBorderStyle  | Border              | Core      |
-| CircleBorderStyle                      | Border              | Core      |
-| MenuSeparatorBorderStyle               | Border              | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Border.Default                    | Border              | Core      |
+| Style.Core.Border.Profile                    | Border              | Core      |
+| Style.Core.Border.CardView                   | Border              | Core      |
+| Style.Core.Border.PanelCardView              | Border              | Core      |
+| Style.Core.Border.MinimalPanelCardView       | Border              | Core      |
+| Style.Core.Border.BrightMinimalPanelCardView | Border              | Core      |
+| Style.Core.Border.Circle                     | Border              | Core      |
+| Style.Core.Border.MenuSeparator              | Border              | Core      |
 
 ## BoxView
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| SeparatorStyle                         | BoxView             | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.BoxView.Default                   | BoxView             | Core      |
+| Style.Core.BoxView.Separator                 | BoxView             | Core      |
 
 ## Button
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultButtonStyle                     | Button              | Core      |
-| ImageButton                            | Button              | Core      |
-| IconButtonStyle                        | Button              | Core      |
-| MaterialDesignIconButtonStyle          | Button              | Core      |
-| PrimaryMaterialDesignIconButtonStyle   | Button              | Core      |
-| LinkButtonStyle                        | Button              | Core      |
-| LinkRoundButtonStyle                   | Button              | Core      |
-| RoundIconButtonStyle                   | Button              | Core      |
-| RoundedLongButtonStyle                 | Button              | Core      |
-| SwipeTemplateBorderStyle               | Button              | Core      |
-| SwipeTemplateButtonStyle               | Button              | Core      |
-| RoundMaterialDesignIconButtonStyle     | Button              | Core      |
-| RoundEmergencyStopIconButtonStyle      | Button              | Core      |
-| GoogleLoginButtonStyle                 | Button              | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Button.Default                    | Button              | Core      |
+| Style.Core.ImageButton.Default               | ImageButton         | Core      |
+| Style.Core.Button.Icon                       | Button              | Core      |
+| Style.Core.Button.IconPrimary                | Button              | Core      |
+| Style.Core.Button.Icon.MaterialDesign        | Button              | Core      |
+| Style.Core.Button.IconPrimary.MaterialDesign | Button              | Core      |
+| Style.Core.Button.Link                       | Button              | Core      |
+| Style.Core.Button.LinkRound                  | Button              | Core      |
+| Style.Core.Button.IconRound                  | Button              | Core      |
+| Style.Core.Button.RoundedLong                | Button              | Core      |
+| Style.Core.Button.Setup                      | Button              | Core      |
+| Style.Core.Button.Swipe                      | Button              | Core      |
+| Style.Core.Button.IconRound.MaterialDesign   | Button              | Core      |
+| Style.Core.Button.IconRound.EmergencyStop    | Button              | Core      |
+| Style.Core.Button.LoginGoogle                | Button              | Core      |
 
 ## CheckBox
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultCheckBoxStyle                   | CheckBox            | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.CheckBox.Default                  | CheckBox            | Core      |
 
 ## DatePicker
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultDatePickerStyle                 | DatePicker          | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.DatePicker.Default                | DatePicker          | Core      |
 
 ## Editor / BorderlessEditor
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultEditorStyle                     | Editor              | Core      |
-| DefaultBorderlessEditorStyle           | BorderlessEditor    | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Editor.Default                    | Editor              | Core      |
+| Style.Core.BorderlessEditor.Default          | BorderlessEditor    | Core      |
 
 ## Entry / BorderlessEntry
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultEntryStyle                      | Entry               | Core      |
-| NumericEntryStyle                      | Entry               | Core      |
-| PasswordEntryStyle                     | Entry               | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Entry.Default                     | Entry               | Core      |
+| Style.Core.Entry.Numeric                     | Entry               | Core      |
+| Style.Core.Entry.Password                    | Entry               | Core      |
+| Style.Core.BorderlessEntry.Default           | BorderlessEntry     | Core      |
+| Style.Core.BorderlessEntry.Numeric           | BorderlessEntry     | Core      |
+| Style.Core.BorderlessEntry.Password          | BorderlessEntry     | Core      |
 
 ## Frame
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultFrameStyle                      | Frame               | Core      |
-| ListViewItemFrameStyle                 | Frame               | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Frame.Default                     | Frame               | Core      |
+| Style.Core.Frame.ListViewItem                | Frame               | Core      |
 
 ## Grid / TapAnimationGrid
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultGridStyle                       | Grid                | Core      |
-| DefaultSettingsGridStyle               | Grid                | Core      |
-| WarningGridStyle                       | Grid                | Core      |
-| CriticalErrorGridStyle                 | Grid                | Core      |
-| DefaultPanelGridStyle                  | Grid                | Core      |
-| ModalPanelGridStyle                    | Grid                | Core      |
-| ShellTitleViewGridStyle                | Grid                | Core      |
-| DefaultTapAnimationGridStyle           | TapAnimationGrid    | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Grid.Default                      | Grid                | Core      |
+| Style.Core.Grid.Settings                     | Grid                | Core      |
+| Style.Core.Grid.Warning                      | Grid                | Core      |
+| Style.Core.Grid.CriticalError                | Grid                | Core      |
+| Style.Core.Grid.Panel                        | Grid                | Core      |
+| Style.Core.Grid.Panel.Modal                  | Grid                | Core      |
+| Style.Core.Grid.ShellTitleView               | Grid                | Core      |
+| Style.Core.TapAnimationGrid.Default          | TapAnimationGrid    | Core      |
 
 ## IndicatorView
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultIndicatorViewStyle              | IndicatorView       | Core      |
+| Key                                          | TargetType          | Library   |
+| ---------------------------------------------|:-------------------:| ---------:|
+| Style.Core.IndicatorView.Default             | IndicatorView       | Core      |
  
 ## Label
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultLabelStyle                      | Label               | Core      |
-| LabelStyle                             | Label               | Core      |
-| IconLabelStyle                         | Label               | Core      |
-| MaterialSettingsIconLabelStyle         | Label               | Core      |
-| TextInputLayoutMaterialIconLabelStyle  | Label               | Core      |
-| MaterialFontFamilyIconLabelStyle       | Label               | Core      |
-| PrimaryMaterialFontFamilyIconLabelStyle| Label               | Core      |
-| MediumLabelStyle                       | Label               | Core      |
-| SmallLabelStyle                        | Label               | Core      |
-| VerySmallLabelStyle                    | Label               | Core      |
-| SetupLabelStyle                        | Label               | Core      |
-| LinkLabelStyle                         | Label               | Core      |
-| PrimaryLabelStyle                      | Label               | Core      |
-| PrimaryDarkLabelStyle                  | Label               | Core      |
-| WarningLabelStyle                      | Label               | Core      |
-| ErrorLabelStyle                        | Label               | Core      |
-| ShellLabelStyle                        | Label               | Core      |
-| SettingsLabelStyle                     | Label               | Core      |
-| SettingsSmallLabelStyle                | Label               | Core      |
-| HeadlineLabelStyle                     | Label               | Core      |
-| PrimaryHeadlineLabelStyle              | Label               | Core      |
-| TitleViewHeadlineLabelStyle            | Label               | Core      |
-| PrimaryDarkHeadlineLabelStyle          | Label               | Core      |
-| SwipeTemplateButtonStyle               | Label               | Core      |
-| OptionButtonLabelStyle                 | Label               | Core      |
-| GroupingHeaderLabelStyle               | Label               | Core      |
-| SwipeTemplateMaterialButtonStyle       | Label               | Core      |
-| MaterialFontIconSpanStyle              | Label               | Core      |
-| FontIconSpanStyle                      | Label               | Core      |
-| MaterialFontFamilyIconSmallLabelStyle  | Label               | Core      |
-| MaterialSwipeTemplateButtonStyle       | Label               | Core      |
+| Key                                                    | TargetType          | Library   |
+| -------------------------------------------------------|:-------------------:| ---------:|
+| Style.Core.Label.Default                               | Label               | Core      |
+| Style.Core.Label.Icon                                  | Label               | Core      |
+| Style.Core.Label.Icon.MaterialDesign                   | Label               | Core      |
+| Style.Core.Label.Icon.MaterialDesign.TextInputLayout   | Label               | Core      |
+| Style.Core.Label.IconPrimary.MaterialDesign            | Label               | Core      |
+| Style.Core.Label.Medium                                | Label               | Core      |
+| Style.Core.Label.Small                                 | Label               | Core      |
+| Style.Core.Label.VerySmall                             | Label               | Core      |
+| Style.Core.Label.Setup                                 | Label               | Core      |
+| Style.Core.Label.Link                                  | Label               | Core      |
+| Style.Core.Label.Primary                               | Label               | Core      |
+| Style.Core.Label.PrimaryDark                           | Label               | Core      |
+| Style.Core.Label.Warning                               | Label               | Core      |
+| Style.Core.Label.Error                                 | Label               | Core      |
+| Style.Core.Label.Shell                                 | Label               | Core      |
+| Style.Core.Label.Settings                              | Label               | Core      |
+| Style.Core.Label.SettingsSmall                         | Label               | Core      |
+| Style.Core.Label.Headline                              | Label               | Core      |
+| Style.Core.Label.HeadlinePrimary                       | Label               | Core      |
+| Style.Core.Label.HeadlinePrimaryDark                   | Label               | Core      |
+| Style.Core.Label.TitleView                             | Label               | Core      |
+| Style.Core.Label.IconSwipe                             | Label               | Core      |
+| Style.Core.Label.IconSwipe.MaterialDesign              | Label               | Core      |
+| Style.Core.Label.Option                                | Label               | Core      |
+| Style.Core.Label.GroupingHeader                        | Label               | Core      |
+| Style.Core.Span.IconTiny.MaterialDesign                | Label               | Core      |
+| Style.Core.Span.Icon.MaterialDesign                    | Span                | Core      |
+| Style.Core.Span.Icon                                   | Span                | Core      |
 
 ## ListView
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultListViewStyle                   | ListView            | Core      |
+| Style.Core.ListView.Default            | ListView            | Core      |
 
 ## Page
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultPageStyle                       | Page                | Core      |
-| ModalPageStyle                         | Page                | Core      |
-| SettingsPageStyle                      | Page                | Core      |
+| Style.Core.Page.Default                | Page                | Core      |
+| Style.Core.NavigationPage.Default      | NavigationPage      | Core      |
+| Style.Core.TabbedPage.Default          | TabbedPage          | Core      |
+| Style.Core.ContentPage.Default         | ContentPage         | Core      |
+| Style.Core.ContentPage.Modal           | ContentPage         | Core      |
+| Style.Core.ContentPage.Settings        | ContentPage         | Core      |
 
 ## Picker
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultPickerStyle                     | Picker              | Core      |
+| Style.Core.Picker.Default              | Picker              | Core      |
 
 ## ProgressBar
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultProgressBarStyle                | ProgressBar         | Core      |
+| Style.Core.ProgressBar.Default         | ProgressBar         | Core      |
 
 ## RadioButton
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultRadioButtonStyle                | RadioButton         | Core      |
+| Style.Core.RadioButton.Default         | RadioButton         | Core      |
 
 ## RefreshView
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultRefreshViewStyle                | RefreshView         | Core      |
+| Style.Core.RefreshView.Default         | RefreshView         | Core      |
 
 ## SearchBar
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSearchBarStyle                  | SearchBar           | Core      |
+| Style.Core.SearchBar.Default           | SearchBar           | Core      |
 
 ## SearchHandler
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSearchHandlerStyle              | SearchHandler       | Core      |
-
-## Shadow
-
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultShadowStyle                     | Shadow              | Core      |
-| CardViewShadowStyle                    | Shadow              | Core      |
+| Style.Core.SearchHandler.Default       | SearchHandler       | Core      |
 
 ## Shell
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| BaseStyle                              | Element             | Core      |
-| DefaultShellStyle                      | Shell               | Core      |
-| DefaultFlyoutItemStyle                 | FlyoutItem          | Core      |
+| Style.Core.Shell.Default               | Shell               | Core      |
+| Style.Core.FlyoutItem.Default          | FlyoutItem          | Core      |
 
 ## Slider
 
@@ -334,150 +332,156 @@ https://github.com/AndreasReitberger/SharedMauiXamlStyles/issues/43
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| StackLayoutHeaderStyle                 | StackLayout         | Core      |
-| ModalInputPageStackLayoutStyle         | StackLayout         | Core      |
-| VerticalStackLayoutHeaderStyle         | VerticalStackLayout | Core      |
-| VerticalModalInputPageStackLayoutStyle | VerticalStackLayout | Core      |
-| HorizontalStackLayoutHeaderStyle       | HorizontalStackLayout  | Core   |
-| HorizontalModalInputPageStackLayoutStyle| HorizontalStackLayout | Core   |
+| Style.Core.StackLayout.Header          | StackLayout         | Core      |
+| Style.Core.StackLayout.Modal           | StackLayout         | Core      |
+| Style.Core.VerticalStackLayout.Header  | VerticalStackLayout | Core      |
+| Style.Core.VerticalStackLayout.Modal   | VerticalStackLayout | Core      |
+| Style.Core.HorizontalStackLayout.Header| HorizontalStackLayout | Core   |
+| Style.Core.HorizontalStackLayout.Modal | HorizontalStackLayout | Core   |
 
 ## SwipeItem
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSwipeItemStyle                  | SwipeItem           | Core      |
+| Style.Core.SwipeItem.Default           | SwipeItem           | Core      |
 
 ## Switch
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSwitchStyle                     | Switch              | Core      |
+| Style.Core.Switch.Default              | Switch              | Core      |
 
 ## TimePicker
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultTimePickerStyle                 | TimePicker          | Core      |
+| Style.Core.TimePicker.Default          | TimePicker          | Core      |
 
 ## SfAccordion
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfAccordionStyle                | SfAccordion         | Syncfusion|
-| DefaultAccordionItemStyle              | AccordionItem       | Syncfusion|
+| Style.Syncfusion.SfAccordion.Default   | SfAccordion         | Syncfusion|
+| Style.Syncfusion.AccordionItem.Default | AccordionItem       | Syncfusion|
 
 ## SfAutocomplete
 
-| Key                                    | TargetType             | Library   |
-| ---------------------------------------|:----------------------:| ---------:|
-| DefaultSfAutocompleteStyle             | SfAutocomplete         | Syncfusion|
-| DefaultMultiSelectAutoCompleteStyle    | MultiSelectAutoComplete| Syncfusion|
+| Key                                                 | TargetType             | Library   |
+| ----------------------------------------------------|:----------------------:| ---------:|
+| Style.Syncfusion.SfAutocomplete.Default             | SfAutocomplete         | Syncfusion|
+| Style.Syncfusion.MultiSelectAutoComplete.Default    | MultiSelectAutoComplete| Syncfusion|
 
 ## SfBadgeView
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfBadgeViewStyle                | SfBadgeView         | Syncfusion|
-| HyperlinkSfBadgedViewStyle             | SfBadgeView         | Syncfusion|
+| Style.Syncfusion.SfBadgeView.Default   | SfBadgeView         | Syncfusion|
+| Style.Syncfusion.SfBadgeView.Hyperlink | SfBadgeView         | Syncfusion|
 
 ## SfBusyIndicator
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfBusyIndicatorStyle            | SfBusyIndicator     | Syncfusion|
+| Key                                      | TargetType          | Library   |
+| -----------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfBusyIndicator.Default | SfBusyIndicator     | Syncfusion|
 
 ## SfCartesianChart
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| NumericOnlySfCartesianChartStyle       | SfCartesianChart    | Syncfusion|
-| DefaultChartAxisLabelStyle             | ChartAxisLabelStyle | Syncfusion|
-| DefaultMajorGridChartLineStyle         | ChartLineStyle      | Syncfusion|
-| DefaultAxisChartLineStyle              | ChartLineStyle      | Syncfusion|
-| DefaultMinorGridChartLineStyle         | ChartLineStyle      | Syncfusion|
-| DefaultMajorChartAxisTickStyle         | ChartAxisTickStyle  | Syncfusion|
+| Key                                                | TargetType          | Library   |
+| ---------------------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfCartesianChart.Default          | SfCartesianChart    | Syncfusion|
+| Style.Syncfusion.ChartLineStyle.Default.Major      | ChartAxisLabelStyle | Syncfusion|
+| Style.Syncfusion.ChartLineStyle.Default.AxisChart  | ChartLineStyle      | Syncfusion|
+| Style.Syncfusion.ChartLineStyle.Default.Minor      | ChartLineStyle      | Syncfusion|
+| Style.Syncfusion.ChartAxisTickStyle.Default.Major  | ChartLineStyle      | Syncfusion|
 
 ## SfChip
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| faultSfChipStyle                       | SfChip              | Syncfusion|
-| ColorSelectionSfChipStyle              | SfChip              | Syncfusion|
-| DefaultSfChipGroupStyle                | SfChipGroup         | Syncfusion|
+| Style.Syncfusion.SfChip.Default        | SfChip              | Syncfusion|
+| Style.Syncfusion.SfChip.ColorSelection | SfChip              | Syncfusion|
+| Style.Syncfusion.SfChipGroup.Default   | SfChipGroup         | Syncfusion|
 
 ## SfComboBox
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfComboBoxStyle                 | SfComboBox          | Syncfusion|
-| DefaultMultiSelectComboBox             | MultiSelectComboBox | Syncfusion|
+| Key                                           | TargetType          | Library   |
+| ----------------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfComboBox.Default           | SfComboBox          | Syncfusion|
+| Style.Syncfusion.MultiSelectComboBox.Default  | MultiSelectComboBox | Syncfusion|
 
 ## SfExpander
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfExpanderStyle                 | SfExpander          | Syncfusion|
+| Style.Syncfusion.SfExpander.Default    | SfExpander          | Syncfusion|
 
 ## SfListView
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfListViewStyle                 | SfListView          | Syncfusion|
-| DeleteEditGestureSwipeSfListViewStyle  | SfListView          | Syncfusion|
+| Key                                           | TargetType          | Library   |
+| ----------------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfListView.Default           | SfListView          | Syncfusion|
+| Style.Syncfusion.SfListView.Swipe.DeleteEdit  | SfListView          | Syncfusion|
 
 ## SfMaskedEntry
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfMaskedEntryStyle              | SfMaskedEntry       | Syncfusion|
+| Style.Syncfusion.SfMaskedEntry.Default | SfMaskedEntry       | Syncfusion|
 
 ## SfNumericEntry
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfNumericEntryStyle             | SfNumericEntry      | Syncfusion|
-| CurrencySfNumericEntryStyle            | SfNumericEntry      | Syncfusion|
-| PercentageSfNumericEntryStyle          | SfNumericEntry      | Syncfusion|
+| Key                                      | TargetType          | Library   |
+| -----------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfNumericEntry.Default  | SfNumericEntry      | Syncfusion|
+| Style.Syncfusion.SfNumericEntry.Currency | SfNumericEntry      | Syncfusion|
+| Style.Syncfusion.SfNumericEntry.Percent  | SfNumericEntry      | Syncfusion|
+
+## SfPicker
+
+| Key                                      | TargetType          | Library   |
+| -----------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfPicker.Default        | SfPicker            | Syncfusion|
+| Style.Syncfusion.SfDateTimePicker.Default| SfDateTimePicker    | Syncfusion|
 
 ## SfRadialGauge
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfRadialGaugeStyle              | SfRadialGauge       | Syncfusion|
-| DefaultRadialLineStyle                 | RadialLineStyle     | Syncfusion|
+| Key                                       | TargetType          | Library   |
+| ------------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfRadialGauge.Default    | SfRadialGauge       | Syncfusion|
+| Style.Syncfusion.RadialLineStyle.Default  | RadialLineStyle     | Syncfusion|
 
 ## SfRangeSlider
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfRangeSliderStyle              | SfRangeSlider       | Syncfusion|
+| Style.Syncfusion.SfRangeSlider.Default | SfRangeSlider       | Syncfusion|
 
 ## SfRating
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfRatingStyle                   | SfRating            | Syncfusion|
+| Style.Syncfusion.SfRating.Default      | SfRating            | Syncfusion|
 
 ## SfSlider
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfSliderStyle                   | SfSlider            | Syncfusion|
-| PrimraySfSliderStyle                   | SfSlider            | Syncfusion|
-| PercentageSfSliderStyle                | SfSlider            | Syncfusion|
+| Style.Syncfusion.SfSlider.Default      | SfSlider            | Syncfusion|
+| Style.Syncfusion.SfSlider.Primray      | SfSlider            | Syncfusion|
+| Style.Syncfusion.SfSlider.Percent      | SfSlider            | Syncfusion|
 
 ## SfTabView
 
 | Key                                    | TargetType          | Library   |
 | ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfTabViewStyle                  | SfTabView           | Syncfusion|
-| DefaultSfTabViewItemStyle              | SfTabItem           | Syncfusion|
+| Style.Syncfusion.SfTabView.Default     | SfTabView           | Syncfusion|
+| Style.Syncfusion.SfTabItem.Default     | SfTabItem           | Syncfusion|
 
 ## SfTextInputLayout
 
-| Key                                    | TargetType          | Library   |
-| ---------------------------------------|:-------------------:| ---------:|
-| DefaultSfTextInputLayoutStyle          | SfTextInputLayout   | Syncfusion|
+| Key                                        | TargetType          | Library   |
+| -------------------------------------------|:-------------------:| ---------:|
+| Style.Syncfusion.SfTextInputLayout.Default | SfTextInputLayout   | Syncfusion|
 
 
 # Licenses & Thirdparty

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/AppShell.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/AppShell.xaml
@@ -7,7 +7,7 @@
     xmlns:views="clr-namespace:SharedMauiXamlStylesLibrary.SampleApp.Views"
     xmlns:viewModels="clr-namespace:SharedMauiXamlStylesLibrary.SampleApp.ViewModels"   
     
-    Style="{StaticResource DefaultShellStyle}"
+    Style="{StaticResource Style.Core.Shell.Default}"
     FlyoutBehavior="{OnPlatform WinUI=Locked, Default={OnIdiom Tablet=Locked, Default=Flyout}}"
     FlyoutBackgroundColor="{AppThemeBinding Light={OnPlatform WinUI={StaticResource Gray100}, Default={StaticResource White}}, Dark={OnPlatform WinUI={StaticResource Gray900}, Default={StaticResource Black}}}"
     
@@ -45,7 +45,7 @@
                 RowDefinitions="*,*"
                 >
                 <Label
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     Text="Darkmode: "
                     VerticalTextAlignment="Center"
                     />
@@ -56,7 +56,7 @@
 
                 <Label
                     Grid.Row="1"
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     Text="Color:"
                     VerticalTextAlignment="Center"
                     />

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -50,6 +50,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary.Syncfusion\SharedMauiXamlStylesLibrary.Syncfusion.csproj" />
+	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ButtonsPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ButtonsPage.xaml
@@ -12,7 +12,7 @@
     xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons;assembly=SharedMauiXamlStylesLibrary.Syncfusion"
     
     Title="ButtonsPage"
-    Style="{StaticResource DefaultPageStyle}"
+    Style="{StaticResource Style.Core.ContentPage.Default}"
     x:DataType="viewModels:ButtonsPageViewModel"   
     >
     <ContentPage.Resources>
@@ -25,39 +25,39 @@
                 Text="Text Buttons"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource LabelStyle}"
+                Style="{StaticResource Style.Core.Label.Default}"
                 />
             
             <Button 
                 Margin="8,16"
                 Text="This is a normal button"
-                Style="{StaticResource DefaultButtonStyle}"
+                Style="{StaticResource Style.Core.Button.Default}"
                 />
             
             <Button 
                 Margin="8,16"
                 Text="This is a green button"
-                Style="{StaticResource DefaultButtonStyle}"
+                Style="{StaticResource Style.Core.Button.Default}"
                 Background="Green"
                 />
             
             <Button 
                 Margin="8,16"
                 Text="This is a link styled button"
-                Style="{StaticResource LinkButtonStyle}"
+                Style="{StaticResource Style.Core.Button.Link}"
                 />
             
             
             <Button 
                 Margin="8,16"
                 Text="This is a link styled button with a round frame"
-                Style="{StaticResource LinkRoundButtonStyle}"
+                Style="{StaticResource Style.Core.Button.LinkRound}"
                 />
             
             <Button 
                 Margin="8,16"
                 Text="This is a normal button"
-                Style="{StaticResource RoundedLongButtonStyle}"
+                Style="{StaticResource Style.Core.Button.RoundedLong}"
                 />
             
             <BoxView />
@@ -67,7 +67,7 @@
                 Text="Icon Buttons"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource LabelStyle}"
+                Style="{StaticResource Style.Core.Label.Default}"
                 />
 
             <Grid
@@ -77,26 +77,26 @@
             <Button 
                 Margin="8,16"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Favourite}"
-                Style="{StaticResource PrimaryIconButtonStyle}"
+                Style="{StaticResource Style.Core.Button.IconPrimary}"
                 />
             <Button 
                 Grid.Column="1"
                 Margin="8,16"
                 Text="{x:Static icons:MaterialIcons.PhonePlusOutline}"
-                Style="{StaticResource PrimaryMaterialDesignIconButtonStyle}"
+                Style="{StaticResource Style.Core.Button.IconPrimary.MaterialDesign}"
                 />
             <Button 
                 Grid.Column="2"
                 Margin="8,16"
                 Text="{x:Static icons:MaterialIcons.ProgressCheck}"
-                Style="{StaticResource PrimaryMaterialDesignIconButtonStyle}"
+                Style="{StaticResource Style.Core.Button.IconPrimary.MaterialDesign}"
                 />
             <Button 
                 Grid.Row="1"
                 Grid.Column="0"
                 Margin="8,16"
                 Text="{x:Static icons:MaterialIcons.ProgressCheck}"
-                Style="{StaticResource PrimaryMaterialDesignIconButtonStyle}"
+                Style="{StaticResource Style.Core.Button.IconPrimary.MaterialDesign}"
                 />
             </Grid>
         </VerticalStackLayout>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/EntryPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/EntryPage.xaml
@@ -14,7 +14,7 @@
     xmlns:editors="clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs"
     
     Title="ButtonsPage"
-    Style="{StaticResource DefaultPageStyle}"
+    Style="{StaticResource Style.Core.ContentPage.Default}"
     x:DataType="viewModels:EntryPageViewModel"   
     >
     <ContentPage.Resources>
@@ -27,7 +27,7 @@
                 Text="Entries"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource LabelStyle}"
+                Style="{StaticResource Style.Core.Label.Default}"
                 />
             
             <Entry 
@@ -38,7 +38,7 @@
             <editors:SfNumericEntry 
                 Margin="8,16"
                 Value="{Binding SampleValue}"
-                Style="{StaticResource DefaultSfNumericEntryStyle}"
+                Style="{StaticResource Style.Syncfusion.SfNumericEntry.Default}"
                 Background="Green"
                 />
             

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/LabelsPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/LabelsPage.xaml
@@ -10,7 +10,7 @@
     xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons;assembly=SharedMauiXamlStylesLibrary.Syncfusion"
     
     Title="LabelsPage"
-    Style="{StaticResource DefaultPageStyle}"
+    Style="{StaticResource Style.Core.ContentPage.Default}"
     x:DataType="viewModels:LabesPageViewModel"   
     >
     <ScrollView>
@@ -20,35 +20,35 @@
                 Text="This is a medium label"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource MediumLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Medium}"
                 />
             <Label 
                 Margin="2,16"
                 Text="This is a normal label"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource LabelStyle}"
+                Style="{StaticResource Style.Core.Label.Default}"
                 />
             <Label 
                 Margin="2,16"
                 Text="This is a small label"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource SmallLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Small}"
                 />
             <Label 
                 Margin="2,16"
                 Text="This is a very small label"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource VerySmallLabelStyle}"
+                Style="{StaticResource Style.Core.Label.VerySmall}"
                 />
             <Label 
                 Margin="2,16"
                 Text="This is a primary color label"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource PrimaryLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Primary}"
                 />
 
             <Label 
@@ -56,7 +56,7 @@
                 Text="This is a headline"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                 />
 
             <BoxView
@@ -67,7 +67,7 @@
                 Text="{x:Static icons:MaterialIcons.HeartOutline}"
                 VerticalTextAlignment="Center" 
                 HorizontalTextAlignment="Center"
-                Style="{StaticResource PrimaryMaterialFontFamilyIconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.IconPrimary.MaterialDesign}"
                 />
             
         </VerticalStackLayout>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/TabViewPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/TabViewPage.xaml
@@ -13,14 +13,14 @@
     xmlns:tabView="clr-namespace:Syncfusion.Maui.TabView;assembly=Syncfusion.Maui.TabView"
     
     Title="TabViewPage"
-    Style="{StaticResource DefaultPageStyle}"
+    Style="{StaticResource Style.Core.ContentPage.Default}"
     x:DataType="viewModels:TabViewPageViewModel"   
     >
     <ContentPage.Resources>
         <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
     </ContentPage.Resources>
     <tabView:SfTabView
-        Style="{StaticResource DefaultSfTabViewStyle}"
+        Style="{StaticResource Style.Syncfusion.SfTabView.Default}"
         >
         <tabView:SfTabItem
             Header="Tab1"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAccordion.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAccordion.xaml
@@ -16,11 +16,11 @@
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" Black="{StaticResource Black}" White="{StaticResource White}" />
 
     <!-- Docs: https://help.syncfusion.com/maui/accordion/ -->
-    <Style x:Key="DefaultSfAccordionStyle" TargetType="expander:SfAccordion">
+    <Style x:Key="Style.Syncfusion.SfAccordion.Default" TargetType="expander:SfAccordion">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
-    
-    <Style x:Key="DefaultAccordionItemStyle" TargetType="expander:AccordionItem">
+
+    <Style x:Key="Style.Syncfusion.AccordionItem.Default" TargetType="expander:AccordionItem">
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup>
@@ -41,5 +41,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="expander:SfAccordion" BasedOn="{StaticResource DefaultSfAccordionStyle}"/>
+    <Style TargetType="expander:SfAccordion" BasedOn="{StaticResource Style.Syncfusion.SfAccordion.Default}"/>
+    <Style TargetType="expander:AccordionItem" BasedOn="{StaticResource Style.Syncfusion.AccordionItem.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAutoComplete.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAutoComplete.xaml
@@ -15,7 +15,7 @@
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="DefaultSfAutocompleteStyle" TargetType="inputs:SfAutocomplete">
+    <Style x:Key="Style.Syncfusion.SfAutocomplete.Default" TargetType="inputs:SfAutocomplete">
         <Setter Property="FontSize" Value="Default" />
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
@@ -41,9 +41,9 @@
        -->
     </Style>
 
-    <Style TargetType="inputs:SfAutocomplete" BasedOn="{StaticResource DefaultSfAutocompleteStyle}"/>
+    <Style TargetType="inputs:SfAutocomplete" BasedOn="{StaticResource Style.Syncfusion.SfAutocomplete.Default}"/>
 
-    <Style x:Key="DefaultMultiSelectAutoCompleteStyle" TargetType="controls:MultiSelectAutoComplete">
+    <Style x:Key="Style.Syncfusion.MultiSelectAutoComplete.Default" TargetType="controls:MultiSelectAutoComplete">
         <Setter Property="FontSize" Value="Default" />
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
@@ -73,6 +73,6 @@
         -->
     </Style>
 
-    <Style TargetType="controls:MultiSelectAutoComplete" BasedOn="{StaticResource DefaultMultiSelectAutoCompleteStyle}"/>
+    <Style TargetType="controls:MultiSelectAutoComplete" BasedOn="{StaticResource Style.Syncfusion.MultiSelectAutoComplete.Default}"/>
 
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfBadgeView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfBadgeView.xaml
@@ -10,8 +10,8 @@
     <ResourceDictionary.MergedDictionaries>
         <shared:Colors />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultSfBadgeViewStyle" TargetType="core:SfBadgeView">
+
+    <Style x:Key="Style.Syncfusion.SfBadgeView.Default" TargetType="core:SfBadgeView">
         <Setter Property="BadgeSettings">
             <Setter.Value>
                 <core:BadgeSettings
@@ -26,9 +26,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="core:SfBadgeView" BasedOn="{StaticResource DefaultSfBadgeViewStyle}" />
+    <Style TargetType="core:SfBadgeView" BasedOn="{StaticResource Style.Syncfusion.SfBadgeView.Default}" />
 
-    <Style x:Key="HyperlinkSfBadgedViewStyle" TargetType="core:SfBadgeView">
+    <Style x:Key="Style.Syncfusion.SfBadgeView.Hyperlink" TargetType="core:SfBadgeView">
         <Setter Property="BadgeSettings">
             <Setter.Value>
                 <core:BadgeSettings

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfBusyIndicator.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfBusyIndicator.xaml
@@ -10,8 +10,8 @@
     <ResourceDictionary.MergedDictionaries>
         <shared:Colors />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultSfBusyIndicatorStyle" TargetType="core:SfBusyIndicator">
+
+    <Style x:Key="Style.Syncfusion.SfBusyIndicator.Default" TargetType="core:SfBusyIndicator">
         <Setter Property="AnimationType" Value="CircularMaterial" />
         <Setter Property="SizeFactor" Value="0.7" />
         <Setter Property="IndicatorColor" Value="{DynamicResource PrimaryColor}" />
@@ -19,5 +19,5 @@
         <Setter Property="OverlayFill" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
-    <Style TargetType="core:SfBusyIndicator" BasedOn="{StaticResource DefaultSfBusyIndicatorStyle}"/>
+    <Style TargetType="core:SfBusyIndicator" BasedOn="{StaticResource Style.Syncfusion.SfBusyIndicator.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfCartesianChart.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfCartesianChart.xaml
@@ -15,28 +15,28 @@
     
     <!-- Docs: https://help.syncfusion.com/maui/cartesian-charts -->
 
-    <Style x:Key="NumericOnlySfCartesianChartStyle" TargetType="chart:SfCartesianChart">
+    <Style x:Key="Style.Syncfusion.SfCartesianChart.Default" TargetType="chart:SfCartesianChart">
 
     </Style>
-    
-    <Style x:Key="DefaultChartAxisLabelStyle" TargetType="chart:ChartAxisLabelStyle">
+
+    <Style x:Key="Style.Syncfusion.ChartAxisLabelStyle.Default" TargetType="chart:ChartAxisLabelStyle">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}" />
     </Style>
 
-    <Style x:Key="DefaultMajorGridChartLineStyle" TargetType="chart:ChartLineStyle">
+    <Style x:Key="Style.Syncfusion.ChartLineStyle.Default.Major" TargetType="chart:ChartLineStyle">
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray400}}" />
     </Style>
 
-    <Style x:Key="DefaultAxisChartLineStyle" TargetType="chart:ChartLineStyle">
+    <Style x:Key="Style.Syncfusion.ChartLineStyle.Default.AxisChart" TargetType="chart:ChartLineStyle">
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray400}}" />
     </Style>
 
-    <Style x:Key="DefaultMinorGridChartLineStyle" TargetType="chart:ChartLineStyle">
+    <Style x:Key="Style.Syncfusion.ChartLineStyle.Default.Minor" TargetType="chart:ChartLineStyle">
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray400}}" />
     </Style>
 
-    <Style x:Key="DefaultMajorChartAxisTickStyle" TargetType="chart:ChartAxisTickStyle">
+    <Style x:Key="Style.Syncfusion.ChartAxisTickStyle.Default.Major" TargetType="chart:ChartAxisTickStyle">
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
         <Setter Property="TickSize" Value="10" />
     </Style> 

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfChips.xaml
@@ -15,24 +15,24 @@
 
     <!-- Docs: https://help.syncfusion.com/maui/chips -->
     <!-- MissingFieldException: Field not found: 'Syncfusion.Maui.Core.SfChip.FontSizeProperty  on Net8? -->
-    <Style x:Key="DefaultSfChipStyle" TargetType="inputLayout:SfChip">
+    <Style x:Key="Style.Syncfusion.SfChip.Default" TargetType="inputLayout:SfChip">
         <Setter Property="FontSize" Value="Default" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratBold}" />
         <Setter Property="StrokeThickness" Value="0"/>
         <Setter Property="Padding" Value="2"/>
     </Style>
 
-    <Style x:Key="ColorSelectionSfChipStyle" TargetType="inputLayout:SfChip" BasedOn="{StaticResource DefaultSfChipStyle}">
+    <Style x:Key="Style.Syncfusion.SfChip.ColorSelection" TargetType="inputLayout:SfChip" BasedOn="{StaticResource Style.Syncfusion.SfChip.Default}">
         <Setter Property="WidthRequest" Value="140"/>
         <Setter Property="HeightRequest" Value="30"/>
         <Setter Property="ShowSelectionIndicator" Value="False"/>
         <Setter Property="SelectionIndicatorColor" Value="{StaticResource Transparent}" />
     </Style>
 
-    <Style TargetType="inputLayout:SfChip" BasedOn="{StaticResource DefaultSfChipStyle}"/>
+    <Style TargetType="inputLayout:SfChip" BasedOn="{StaticResource Style.Syncfusion.SfChip.Default}"/>
 
 
-    <Style x:Key="DefaultSfChipGroupStyle" TargetType="inputLayout:SfChipGroup">
+    <Style x:Key="Style.Syncfusion.SfChipGroup.Default" TargetType="inputLayout:SfChipGroup">
         <Setter Property="SelectionIndicatorColor" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="ChipTextColor" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
         <Setter Property="ChipBackground" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
@@ -54,5 +54,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="inputLayout:SfChipGroup" BasedOn="{StaticResource DefaultSfChipGroupStyle}"/>
+    <Style TargetType="inputLayout:SfChipGroup" BasedOn="{StaticResource Style.Syncfusion.SfChipGroup.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
@@ -15,7 +15,7 @@
     </ResourceDictionary.MergedDictionaries>
 
 
-    <Style x:Key="DefaultSfComboBoxStyle" TargetType="inputs:SfComboBox">
+    <Style x:Key="Style.Syncfusion.SfComboBox.Default" TargetType="inputs:SfComboBox">
         <Setter Property="FontSize" Value="Default" />
         <Setter Property="DropDownIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
@@ -45,9 +45,9 @@
         -->
     </Style>
 
-    <Style TargetType="inputs:SfComboBox" BasedOn="{StaticResource DefaultSfComboBoxStyle}"/>
+    <Style TargetType="inputs:SfComboBox" BasedOn="{StaticResource Style.Syncfusion.SfComboBox.Default}"/>
 
-    <Style x:Key="DefaultMultiSelectComboBox" TargetType="controls:MultiSelectComboBox">
+    <Style x:Key="Style.Syncfusion.MultiSelectComboBox.Default" TargetType="controls:MultiSelectComboBox">
         <Setter Property="FontSize" Value="Default" />
         <Setter Property="DropDownIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
@@ -75,5 +75,5 @@
         -->
     </Style>
 
-    <Style TargetType="controls:MultiSelectComboBox" BasedOn="{StaticResource DefaultMultiSelectComboBox}"/>
+    <Style TargetType="controls:MultiSelectComboBox" BasedOn="{StaticResource Style.Syncfusion.MultiSelectComboBox.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfExpander.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfExpander.xaml
@@ -16,7 +16,7 @@
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" Black="{StaticResource Black}" White="{StaticResource White}" />
 
     <!-- Docs: https://help.syncfusion.com/maui/accordion/ -->
-    <Style x:Key="DefaultSfExpanderStyle" TargetType="expander:SfExpander">
+    <Style x:Key="Style.Syncfusion.SfExpander.Default" TargetType="expander:SfExpander">
         <Setter Property="HeaderBackground" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="HeaderIconColor" Value="{Binding Source={RelativeSource Self}, Path=HeaderBackground, Converter={StaticResource ColorToBlackWhiteConverter}}" />
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
@@ -42,5 +42,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="expander:SfExpander" BasedOn="{StaticResource DefaultSfExpanderStyle}"/>
+    <Style TargetType="expander:SfExpander" BasedOn="{StaticResource Style.Syncfusion.SfExpander.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfListView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfListView.xaml
@@ -11,8 +11,8 @@
         <shared:Colors />
         <ResourceDictionary Source="/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultSfListViewStyle" TargetType="listView:SfListView">
+
+    <Style x:Key="Style.Syncfusion.SfListView.Default" TargetType="listView:SfListView">
         <Setter Property="SelectionBackground" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False" TargetType="listView:SfListView">
@@ -21,9 +21,9 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="listView:SfListView" BasedOn="{StaticResource DefaultSfListViewStyle}" />
+    <Style TargetType="listView:SfListView" BasedOn="{StaticResource Style.Syncfusion.SfListView.Default}" />
 
-    <Style x:Key="DeleteEditGestureSwipeSfListViewStyle" TargetType="listView:SfListView" BasedOn="{StaticResource DefaultSfListViewStyle}">
+    <Style x:Key="Style.Syncfusion.SfListView.Swipe.DeleteEdit" TargetType="listView:SfListView" BasedOn="{StaticResource Style.Syncfusion.SfListView.Default}">
         <Setter Property="AllowSwiping" Value="True" />
         <Setter Property="SwipeThreshold" Value="70" />
         <Setter Property="StartSwipeTemplate" Value="{StaticResource DeleteGestureSwipeTemplate}" />

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfMaskedEntry.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfMaskedEntry.xaml
@@ -14,7 +14,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Docs: https://help.syncfusion.com/maui/masked-entry/getting-started -->
-    <Style x:Key="DefaultSfMaskedEntryStyle" TargetType="inputs:SfMaskedEntry">
+    <Style x:Key="Style.Syncfusion.SfMaskedEntry.Default" TargetType="inputs:SfMaskedEntry">
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="Default" />
@@ -37,5 +37,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="inputs:SfMaskedEntry" BasedOn="{StaticResource DefaultSfMaskedEntryStyle}"/>
+    <Style TargetType="inputs:SfMaskedEntry" BasedOn="{StaticResource Style.Syncfusion.SfMaskedEntry.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfNumericEntry.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfNumericEntry.xaml
@@ -14,7 +14,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Docs: https://help.syncfusion.com/maui/numeric-entry -->
-    <Style x:Key="DefaultSfNumericEntryStyle" TargetType="inputs:SfNumericEntry">
+    <Style x:Key="Style.Syncfusion.SfNumericEntry.Default" TargetType="inputs:SfNumericEntry">
         <Setter Property="Minimum" Value="0" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
@@ -44,13 +44,13 @@
         </Setter>
     </Style>
 
-    <Style x:Key="CurrencySfNumericEntryStyle" TargetType="inputs:SfNumericEntry" BasedOn="{StaticResource DefaultSfNumericEntryStyle}">
+    <Style x:Key="Style.Syncfusion.SfNumericEntry.Currency" TargetType="inputs:SfNumericEntry" BasedOn="{StaticResource Style.Syncfusion.SfNumericEntry.Default}">
         <Setter Property="CustomFormat" Value="C2" />
     </Style>
 
-    <Style x:Key="PercentageSfNumericEntryStyle" TargetType="inputs:SfNumericEntry" BasedOn="{StaticResource DefaultSfNumericEntryStyle}">
+    <Style x:Key="Style.Syncfusion.SfNumericEntry.Percent" TargetType="inputs:SfNumericEntry" BasedOn="{StaticResource Style.Syncfusion.SfNumericEntry.Default}">
         <Setter Property="CustomFormat" Value="P2" />
     </Style>
 
-    <Style TargetType="inputs:SfNumericEntry" BasedOn="{StaticResource DefaultSfNumericEntryStyle}"/>
+    <Style TargetType="inputs:SfNumericEntry" BasedOn="{StaticResource Style.Syncfusion.SfNumericEntry.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfPicker.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfPicker.xaml
@@ -19,7 +19,7 @@
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
     <converters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
 
-    <Style x:Key="DefaultSfPickerStyle" TargetType="picker:SfPicker">
+    <Style x:Key="Style.Syncfusion.SfPicker.Default" TargetType="picker:SfPicker">
         <Setter Property="ColumnDividerColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="Margin" Value="4,2"/>
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
@@ -82,9 +82,9 @@
         </Setter>
         -->
     </Style>
-    <Style TargetType="picker:SfPicker" BasedOn="{StaticResource DefaultSfPickerStyle}"/>
-    
-    <Style x:Key="DefaultSfDateTimePickerStyle" TargetType="picker:SfDateTimePicker">
+    <Style TargetType="picker:SfPicker" BasedOn="{StaticResource Style.Syncfusion.SfPicker.Default}"/>
+
+    <Style x:Key="Style.Syncfusion.SfDateTimePicker.Default" TargetType="picker:SfDateTimePicker">
         <Setter Property="ColumnDividerColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="Margin" Value="4,2"/>
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
@@ -138,6 +138,6 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style TargetType="picker:SfDateTimePicker" BasedOn="{StaticResource DefaultSfDateTimePickerStyle}"/>
+    <Style TargetType="picker:SfDateTimePicker" BasedOn="{StaticResource Style.Syncfusion.SfDateTimePicker.Default}"/>
 
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRadialGauge.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRadialGauge.xaml
@@ -13,14 +13,14 @@
 
     
     <!-- Docs: https://help.syncfusion.com/maui/radial-gauge/overview-->
-    <Style x:Key="DefaultSfRadialGaugeStyle" TargetType="gauge:SfRadialGauge">
+    <Style x:Key="Style.Syncfusion.SfRadialGauge.Default" TargetType="gauge:SfRadialGauge">
         <Setter Property="WidthRequest" Value="250" />
         <Setter Property="HeightRequest" Value="250" />
     </Style>
 
-    <Style TargetType="gauge:SfRadialGauge" BasedOn="{StaticResource DefaultSfRadialGaugeStyle}" />
+    <Style TargetType="gauge:SfRadialGauge" BasedOn="{StaticResource Style.Syncfusion.SfRadialGauge.Default}" />
 
-    <Style x:Key="DefaultRadialLineStyle" TargetType="gauge:RadialLineStyle">
+    <Style x:Key="Style.Syncfusion.RadialLineStyle.Default" TargetType="gauge:RadialLineStyle">
         <Setter Property="Fill" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
         <Setter Property="Thickness" Value="4" />
         <Setter Property="ThicknessUnit" Value="Pixel" />

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRangeSlider.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRangeSlider.xaml
@@ -12,7 +12,7 @@
     </ResourceDictionary.MergedDictionaries>
    
     <!-- Docs: https://help.syncfusion.com/maui/range-slider/getting-started 
-    <Style x:Key="DefaultSfRangeSliderStyle" TargetType="sliders:SfRangeSlider">
+    <Style x:Key="Style.Syncfusion.SfRangeSlider.Default" TargetType="sliders:SfRangeSlider">
         <Setter Property="Visual" Value="Default" />
         <Setter Property="HeightRequest" Value="48" />
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -91,7 +91,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="PrimraySfRangeSliderStyle" TargetType="sliders:SfRangeSlider">
+    <Style x:Key="Style.Syncfusion.SfRangeSlider.Primray" TargetType="sliders:SfRangeSlider">
         <Setter Property="ShowLabels" Value="False" />
         <Setter Property="WidthRequest" Value="290" />
         <Setter Property="HeightRequest" Value="36" />

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRating.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRating.xaml
@@ -14,7 +14,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Docs: https://help.syncfusion.com/maui/rating -->
-    <Style x:Key="DefaultSfRatingStyle" TargetType="inputs:SfRating">
+    <Style x:Key="Style.Syncfusion.SfRating.Default" TargetType="inputs:SfRating">
         <Setter Property="Precision" Value="Half" />
         <Setter Property="RatingSettings">
             <Setter.Value>
@@ -28,5 +28,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="inputs:SfRating" BasedOn="{StaticResource DefaultSfRatingStyle}"/>
+    <Style TargetType="inputs:SfRating" BasedOn="{StaticResource Style.Syncfusion.SfRating.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfSlider.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfSlider.xaml
@@ -13,7 +13,7 @@
     </ResourceDictionary.MergedDictionaries>
     
     <!-- Docs: https://help.syncfusion.com/maui/range-slider/getting-started -->
-    <Style x:Key="DefaultSfSliderStyle" TargetType="sliders:SfSlider">
+    <Style x:Key="Style.Syncfusion.SfSlider.Default" TargetType="sliders:SfSlider">
         <Setter Property="Visual" Value="Default" />
         <Setter Property="HeightRequest" Value="70" />
         <Setter Property="Margin" Value="8,4" />
@@ -100,14 +100,14 @@
         </Setter>
     </Style>
 
-    <Style TargetType="sliders:SfSlider" BasedOn="{StaticResource DefaultSfSliderStyle}" />
+    <Style TargetType="sliders:SfSlider" BasedOn="{StaticResource Style.Syncfusion.SfSlider.Default}" />
 
-    <Style x:Key="PrimraySfSliderStyle" TargetType="sliders:SfSlider">
+    <Style x:Key="Style.Syncfusion.SfSlider.Primray" TargetType="sliders:SfSlider">
         <Setter Property="ShowLabels" Value="False" />
         <Setter Property="WidthRequest" Value="290" />
     </Style>
 
-    <Style x:Key="PercentageSfSliderStyle" TargetType="sliders:SfSlider">
+    <Style x:Key="Style.Syncfusion.SfSlider.Percent" TargetType="sliders:SfSlider">
         <Setter Property="NumberFormat" Value="# %" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTabView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTabView.xaml
@@ -12,16 +12,16 @@
         <shared:Fonts />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultSfTabViewStyle" TargetType="tabView:SfTabView">
+
+    <Style x:Key="Style.Syncfusion.SfTabView.Default" TargetType="tabView:SfTabView">
         <Setter Property="IndicatorBackground" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="TabBarBackground" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
         <Setter Property="IndicatorPlacement" Value="Top"/>
     </Style>
 
-    <Style TargetType="tabView:SfTabView" BasedOn="{StaticResource DefaultSfTabViewStyle}" />
+    <Style TargetType="tabView:SfTabView" BasedOn="{StaticResource Style.Syncfusion.SfTabView.Default}" />
 
-    <Style x:Key="DefaultSfTabViewItemStyle" TargetType="tabView:SfTabItem">
+    <Style x:Key="Style.Syncfusion.SfTabItem.Default" TargetType="tabView:SfTabItem">
         <Setter Property="FontFamily" Value="{StaticResource MontserratMedium}"/>
         <Setter Property="FontSize" Value="Micro"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -42,11 +42,11 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialIconSfTabViewItemStyle" TargetType="tabView:SfTabItem" BasedOn="{StaticResource DefaultSfTabViewItemStyle}">
+    <Style x:Key="MaterialIconSfTabViewItemStyle" TargetType="tabView:SfTabItem" BasedOn="{StaticResource Style.Syncfusion.SfTabItem.Default}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}"/>
         <Setter Property="FontSize" Value="{OnPlatform Android=Default, Default=Small}"/>
     </Style>
 
-    <Style TargetType="tabView:SfTabItem" BasedOn="{StaticResource DefaultSfTabViewItemStyle}"/>
+    <Style TargetType="tabView:SfTabItem" BasedOn="{StaticResource Style.Syncfusion.SfTabItem.Default}"/>
 
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTextInputLayout.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTextInputLayout.xaml
@@ -14,7 +14,7 @@
     </ResourceDictionary.MergedDictionaries>
     
     <!-- Docs: https://help.syncfusion.com/maui/textinputlayout/states-and-colors -->
-    <Style x:Key="DefaultSfTextInputLayoutStyle" TargetType="inputLayout:SfTextInputLayout">
+    <Style x:Key="Style.Syncfusion.SfTextInputLayout.Default" TargetType="inputLayout:SfTextInputLayout">
         <Setter Property="ContainerType" Value="Outlined"/>
         <Setter Property="LeadingViewPosition" Value="Inside"/>
         <Setter Property="ContainerBackground" Value="{AppThemeBinding Light={StaticResource Gray100},Dark={StaticResource Gray950}}"/>
@@ -67,5 +67,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="inputLayout:SfTextInputLayout" BasedOn="{StaticResource DefaultSfTextInputLayoutStyle}"/>
+    <Style TargetType="inputLayout:SfTextInputLayout" BasedOn="{StaticResource Style.Syncfusion.SfTextInputLayout.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ActivityIndicator.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ActivityIndicator.xaml
@@ -9,11 +9,11 @@
         <!--<ResourceDictionary Source="/Themes/SharedIcons.xaml" />-->
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultActivityIndicator" TargetType="ActivityIndicator">
+
+    <Style x:Key="Style.Core.ActivityIndicator.Default" TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
     </Style>
 
-    <Style TargetType="ActivityIndicator" BasedOn="{StaticResource DefaultActivityIndicator}"/>
+    <Style TargetType="ActivityIndicator" BasedOn="{StaticResource Style.Core.ActivityIndicator.Default}"/>
 
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Border.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Border.xaml
@@ -12,13 +12,15 @@
     <!--
     Docs: https://docs.microsoft.com/de-de/dotnet/maui/user-interface/controls/border
     -->
-    <Style TargetType="Border">
+    <Style x:Key="Style.Core.Border.Default" TargetType="Border">
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
         <Setter Property="StrokeShape" Value="Rectangle"/>
         <Setter Property="StrokeThickness" Value="1"/>
     </Style>
 
-    <Style x:Key="ProfileBorderStyle" TargetType="Border">
+    <Style TargetType="Border" BasedOn="{StaticResource Style.Core.Border.Default}"/>
+
+    <Style x:Key="Style.Core.Border.Profile" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.Default}">
         <Setter Property="StrokeShape">
             <Setter.Value>
                 <RoundRectangle CornerRadius="20" />
@@ -27,7 +29,7 @@
         <Setter Property="StrokeThickness" Value="1"/>
     </Style>
 
-    <Style x:Key="CardViewBorderStyle" TargetType="Border">
+    <Style x:Key="Style.Core.Border.CardView" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.Default}">
         <Setter Property="StrokeShape">
             <Setter.Value>
                 <RoundRectangle CornerRadius="30" />
@@ -52,7 +54,7 @@
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"/>
     </Style>
 
-    <Style x:Key="PanelCardViewBorderStyle" TargetType="Border" BasedOn="{StaticResource CardViewBorderStyle}">
+    <Style x:Key="Style.Core.Border.PanelCardView" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.CardView}">
         <Setter Property="Margin" Value="8"/>
         <Setter Property="StrokeShape">
             <Setter.Value>
@@ -61,7 +63,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MinimalPanelCardViewBorderStyle" TargetType="Border" BasedOn="{StaticResource PanelCardViewBorderStyle}">
+    <Style x:Key="Style.Core.Border.MinimalPanelCardView" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.PanelCardView}">
         <Setter Property="Margin" Value="4"/>
         <Setter Property="StrokeShape">
             <Setter.Value>
@@ -70,12 +72,12 @@
         </Setter>
     </Style>
 
-    <Style x:Key="BrightMinimalPanelCardViewBorderStyle" TargetType="Border" BasedOn="{StaticResource MinimalPanelCardViewBorderStyle}">
+    <Style x:Key="Style.Core.Border.BrightMinimalPanelCardView" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.MinimalPanelCardView}">
         <Setter Property="Margin" Value="4,8"/>
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
     </Style>
 
-    <Style x:Key="CircleBorderStyle" TargetType="Border" BasedOn="{StaticResource ProfileBorderStyle}">
+    <Style x:Key="Style.Core.Border.Circle" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.Profile}">
         <Setter Property="WidthRequest" Value="{OnIdiom Phone=64, Default=72}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Phone=64, Default=72}" />
         <Setter Property="StrokeShape">
@@ -86,7 +88,7 @@
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
 
-    <Style x:Key="MenuSeparatorBorderStyle" TargetType="Border" BasedOn="{StaticResource ProfileBorderStyle}">
+    <Style x:Key="Style.Core.Border.MenuSeparator" TargetType="Border" BasedOn="{StaticResource Style.Core.Border.Profile}">
         <Setter Property="StrokeThickness" Value="0" />
         <Setter Property="StrokeShape">
             <Setter.Value>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/BoxView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/BoxView.xaml
@@ -8,13 +8,15 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="SeparatorStyle" TargetType="BoxView">
+
+    <Style x:Key="Style.Core.BoxView.Default" TargetType="BoxView">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
         <Setter Property="HeightRequest" Value="1" />
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
     </Style>
 
     <!--  Common style for separator BoxView  -->
-    <Style TargetType="BoxView" BasedOn="{StaticResource SeparatorStyle}"/>
+    <Style TargetType="BoxView" BasedOn="{StaticResource Style.Core.BoxView.Default}"/>
+
+    <Style x:Key="Style.Core.BoxView.Separator" TargetType="BoxView" BasedOn="{StaticResource Style.Core.BoxView.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -21,7 +21,7 @@
     <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
     <converters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
 
-    <Style x:Key="DefaultButtonStyle" TargetType="Button">
+    <Style x:Key="Style.Core.Button.Default" TargetType="Button">
         <!-- Set Background before setting the TextColor due to the Converter -->
         <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
@@ -47,9 +47,10 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
-    <Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}"/>
+    
+    <Style TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}"/>
 
-    <Style TargetType="ImageButton">
+    <Style x:Key="Style.Core.ImageButton.Default" TargetType="ImageButton">
         <Setter Property="BorderColor" Value="Transparent"/>
         <Setter Property="BorderWidth" Value="0"/>
         <Setter Property="CornerRadius" Value="0"/>
@@ -70,8 +71,10 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
-    
-    <Style x:Key="IconButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+
+    <Style TargetType="ImageButton" BasedOn="{StaticResource Style.Core.ImageButton.Default}"/>
+
+    <Style x:Key="Style.Core.Button.Icon" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
         <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
@@ -100,7 +103,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="PrimaryIconButtonStyle" TargetType="Button" BasedOn="{StaticResource IconButtonStyle}">
+    <Style x:Key="Style.Core.Button.IconPrimary" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
         <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -123,12 +126,12 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialDesignIconButtonStyle" TargetType="Button" BasedOn="{StaticResource IconButtonStyle}">
+    <Style x:Key="Style.Core.Button.Icon.MaterialDesign" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
         <Setter Property="FontSize" Value="{OnIdiom Desktop=Medium, Default=Large}" />
     </Style>
 
-    <Style x:Key="PrimaryMaterialDesignIconButtonStyle" TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButtonStyle}">
+    <Style x:Key="Style.Core.Button.IconPrimary.MaterialDesign" TargetType="Button" BasedOn="{StaticResource MaterialDesignStyle.Core.Button.Icon}">
         <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -151,7 +154,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="LinkButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+    <Style x:Key="Style.Core.Button.Link" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
         <Setter Property="Margin" Value="4,6" />
         <Setter Property="BackgroundColor" Value="{StaticResource Transparent}" />
         <Setter Property="TextColor" Value="{StaticResource Blue}" />
@@ -176,14 +179,14 @@
         </Setter>
     </Style>
 
-    <Style x:Key="LinkRoundButtonStyle" TargetType="Button" BasedOn="{StaticResource LinkButtonStyle}">
+    <Style x:Key="Style.Core.Button.LinkRound" TargetType="Button" BasedOn="{StaticResource LinkButtonStyle}">
         <Setter Property="BorderColor" Value="{StaticResource Blue}" />
         <Setter Property="BorderWidth" Value="2" />
         <Setter Property="HeightRequest" Value="50" />
         <Setter Property="CornerRadius" Value="25" />
     </Style>
 
-    <Style x:Key="RoundIconButtonStyle" BasedOn="{StaticResource IconButtonStyle}" TargetType="Button">
+    <Style x:Key="Style.Core.Button.IconRound" BasedOn="{StaticResource Style.Core.Button.Icon}" TargetType="Button">
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
         <Setter Property="BorderWidth" Value="1" />
         <Setter Property="CornerRadius" Value="25" />
@@ -193,7 +196,7 @@
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
     </Style>
 
-    <Style x:Key="RoundedLongButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+    <Style x:Key="Style.Core.Button.RoundedLong" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
         <Setter Property="Margin" Value="20" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <Setter Property="FontSize" Value="Small" />
@@ -204,23 +207,13 @@
         <Setter Property="BorderWidth" Value="0" />
     </Style>
 
-    <Style x:Key="SetupButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundedLongButtonStyle}">
+    <Style x:Key="Style.Core.Button.Setup" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.RoundedLong}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}"/>
     </Style>
 
     <!--  Common style for swipe template content border control  -->
-    <!-- Delete later due to wrong style naming -->
-    <Style x:Key="SwipeTemplateBorderStyle" TargetType="Button">
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        <Setter Property="HeightRequest" Value="32" />
-        <Setter Property="WidthRequest" Value="32" />
-        <Setter Property="BorderWidth" Value="0" />
-        <Setter Property="CornerRadius" Value="16" />
-    </Style>
-    
-    <Style x:Key="SwipeTemplateButtonStyle" TargetType="Button">
+    <Style x:Key="Style.Core.Button.Swipe" TargetType="Button">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
@@ -230,7 +223,7 @@
         <Setter Property="CornerRadius" Value="16" />
     </Style>
 
-    <Style x:Key="RoundMaterialDesignIconButtonStyle" TargetType="Button">
+    <Style x:Key="Style.Core.Button.IconRound.MaterialDesign" TargetType="Button">
         <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
@@ -240,7 +233,7 @@
         <Setter Property="CornerRadius" Value="{OnIdiom Desktop=32, Tablet=32, Default=25}" />
     </Style>
 
-    <Style x:Key="RoundEmergencyStopIconButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundMaterialDesignIconButtonStyle}">
+    <Style x:Key="Style.Core.Button.IconRound.EmergencyStop" TargetType="Button" BasedOn="{StaticResource RoundMaterialDesignStyle.Core.Button.Icon}">
         <Setter Property="Background" Value="{StaticResource Red}" />
         <Setter Property="BorderColor" Value="{StaticResource Yellow}" />
         <Setter Property="TextColor" Value="{StaticResource White}" />
@@ -251,7 +244,7 @@
         <Setter Property="CornerRadius" Value="{OnIdiom Tablet=35, Phone=25, Default=25}" />
     </Style>
 
-    <Style x:Key="GoogleLoginButtonStyle" TargetType="Button" BasedOn="{StaticResource RoundedLongButtonStyle}">
+    <Style x:Key="Style.Core.Button.LoginGoogle" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.RoundedLong}">
         <Setter Property="Background" Value="{StaticResource White}" />
         <Setter Property="ImageSource">
             <FontImageSource

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/CheckBox.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/CheckBox.xaml
@@ -9,8 +9,8 @@
         <!--<ResourceDictionary Source="/Themes/SharedIcons.xaml" />-->
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultCheckBoxStyle" TargetType="CheckBox">
+
+    <Style x:Key="Style.Core.CheckBox.Default" TargetType="CheckBox">
         <Setter Property="VerticalOptions" Value="Center" />
         <Setter Property="Color" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
@@ -33,5 +33,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}"/>
+    <Style TargetType="CheckBox" BasedOn="{StaticResource Style.Core.CheckBox.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/DatePicker.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/DatePicker.xaml
@@ -8,8 +8,8 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultDatePickerStyle" TargetType="DatePicker">
+
+    <Style x:Key="Style.Core.DatePicker.Default" TargetType="DatePicker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <Setter Property="FontSize" Value="Default"/>
@@ -31,5 +31,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="DatePicker" BasedOn="{StaticResource DefaultDatePickerStyle}" />
+    <Style TargetType="DatePicker" BasedOn="{StaticResource Style.Core.DatePicker.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Editor.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Editor.xaml
@@ -10,8 +10,8 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultEditorStyle" TargetType="Editor">
+
+    <Style x:Key="Style.Core.Editor.Default" TargetType="Editor">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="FontSize" Value="Default" />
@@ -34,7 +34,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="DefaultBorderlessEditorStyle" TargetType="control:BorderlessEditor">
+    <Style x:Key="Style.Core.BorderlessEditor.Default" TargetType="control:BorderlessEditor">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="FontSize" Value="Default" />
@@ -59,7 +59,7 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
-       
-    <Style TargetType="Editor" BasedOn="{StaticResource DefaultEditorStyle}"/>
-    <Style TargetType="control:BorderlessEditor" BasedOn="{StaticResource DefaultBorderlessEditorStyle}"/>
+
+    <Style TargetType="Editor" BasedOn="{StaticResource Style.Core.Editor.Default}"/>
+    <Style TargetType="control:BorderlessEditor" BasedOn="{StaticResource Style.Core.BorderlessEditor.Default}"/>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Entry.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Entry.xaml
@@ -11,8 +11,8 @@
         <!--<ResourceDictionary Source="/Themes/SharedIcons.xaml" />-->
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultEntryStyle" TargetType="Entry">
+
+    <Style x:Key="Style.Core.Entry.Default" TargetType="Entry">
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="Default" />
@@ -37,7 +37,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="DefaultBorderlessEntryStyle" TargetType="control:BorderlessEntry">
+    <Style x:Key="Style.Core.BorderlessEntry.Default" TargetType="control:BorderlessEntry">
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="Default" />
@@ -62,23 +62,23 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Entry" BasedOn="{StaticResource DefaultEntryStyle}" ApplyToDerivedTypes="True"/>
+    <Style TargetType="Entry" BasedOn="{StaticResource Style.Core.Entry.Default}" ApplyToDerivedTypes="True"/>
     <Style TargetType="control:BorderlessEntry" BasedOn="{StaticResource DefaultEntryStyle}" ApplyToDerivedTypes="True"/>
 
-    <Style x:Key="NumericEntryStyle" TargetType="Entry" BasedOn="{StaticResource DefaultEntryStyle}">
+    <Style x:Key="Style.Core.Entry.Numeric" TargetType="Entry" BasedOn="{StaticResource Style.Core.Entry.Default}">
         <Setter Property="Keyboard" Value="Numeric"/>
     </Style>
 
-    <Style x:Key="NumericBorderlessEntryStyle" TargetType="control:BorderlessEntry" BasedOn="{StaticResource DefaultBorderlessEntryStyle}">
+    <Style x:Key="Style.Core.BorderlessEntry.Numeric" TargetType="control:BorderlessEntry" BasedOn="{StaticResource Style.Core.BorderlessEntry.Default}">
         <Setter Property="Keyboard" Value="Numeric"/>
     </Style>
-    
-    <Style x:Key="PasswordEntryStyle" TargetType="Entry" BasedOn="{StaticResource DefaultEntryStyle}">
+
+    <Style x:Key="Style.Core.Entry.Password" TargetType="Entry" BasedOn="{StaticResource DefaultEntryStyle}">
         <Setter Property="IsPassword" Value="True"/>
         <Setter Property="IsSpellCheckEnabled" Value="False" />
     </Style>
 
-    <Style x:Key="PasswordBorderlessEntryStyle" TargetType="control:BorderlessEntry" BasedOn="{StaticResource DefaultBorderlessEntryStyle}">
+    <Style x:Key="Style.Core.BorderlessEntry.Password" TargetType="control:BorderlessEntry" BasedOn="{StaticResource Style.Core.BorderlessEntry.Default}">
         <Setter Property="IsPassword" Value="True"/>
         <Setter Property="IsSpellCheckEnabled" Value="False" />
     </Style>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Frame.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Frame.xaml
@@ -7,16 +7,16 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultFrameStyle" TargetType="Frame">
+
+    <Style x:Key="Style.Core.Frame.Default" TargetType="Frame">
         <Setter Property="HasShadow" Value="False" />
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
         <Setter Property="CornerRadius" Value="8" />
     </Style>
 
-    <Style TargetType="Frame" BasedOn="{StaticResource DefaultFrameStyle}" />
+    <Style TargetType="Frame" BasedOn="{StaticResource Style.Core.Frame.Default}" />
 
-    <Style x:Key="ListViewItemFrameStyle" TargetType="Frame" BasedOn="{StaticResource DefaultFrameStyle}" >
+    <Style x:Key="Style.Core.Frame.ListViewItem" TargetType="Frame" BasedOn="{StaticResource DefaultFrameStyle}" >
         <Setter Property="BorderColor" Value="{StaticResource Transparent}"/>
         <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Light_ItemTemplateBorder}, Dark={StaticResource Dark_ItemTemplateBorder}}" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Grid.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Grid.xaml
@@ -11,7 +11,7 @@
     </ResourceDictionary.MergedDictionaries>
     
     <!--  Common style for TapNavigationGrid  -->
-    <Style x:Key="DefaultTapAnimationGridStyle" TargetType="control:TapAnimationGrid">
+    <Style x:Key="Style.Core.TapAnimationGrid.Default" TargetType="control:TapAnimationGrid">
         <Setter Property="RowSpacing" Value="0"/>
         <!-- Seems to be needed since 7.x.x -->
         <Setter Property="RowDefinitions">
@@ -32,7 +32,7 @@
     </Style>
     
     <!--  Common style for SettingsGrid  -->
-    <Style x:Key="DefaultGridStyle" TargetType="Grid">
+    <Style x:Key="Style.Core.Grid.Default" TargetType="Grid">
         <Setter Property="RowSpacing" Value="0"/>
         <!-- Seems to be needed since 7.x.x -->
         <Setter Property="RowDefinitions">
@@ -50,30 +50,30 @@
         </Style.Triggers>
     </Style>
 
-    <Style x:Key="DefaultSettingsGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
+    <Style x:Key="Style.Core.Grid.Settings" TargetType="Grid" BasedOn="{StaticResource Style.Core.Grid.Default}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
     </Style>
     <!--  Common style for WarningGrid  -->
-    <Style x:Key="WarningGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
+    <Style x:Key="Style.Core.Grid.Warning" TargetType="Grid" BasedOn="{StaticResource Style.Core.Grid.Default}">
         <Setter Property="Background" Value="{StaticResource Yellow}" />
     </Style>
     <!--  Common style for ErrorGrid  -->
-    <Style x:Key="CriticalErrorGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
+    <Style x:Key="Style.Core.Grid.CriticalError" TargetType="Grid" BasedOn="{StaticResource Style.Core.Grid.Default}">
         <Setter Property="Background" Value="{StaticResource Red}" />
     </Style>
     <!--  Common style for SettingsGrid  -->
-    <Style x:Key="DefaultPanelGridStyle" TargetType="Grid" BasedOn="{StaticResource DefaultGridStyle}">
+    <Style x:Key="Style.Core.Grid.Panel" TargetType="Grid" BasedOn="{StaticResource Style.Core.Grid.Default}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
     </Style>
     <!--  Common style for ModalGrid  -->
-    <Style x:Key="ModalPanelGridStyle" TargetType="Grid">
+    <Style x:Key="Style.Core.Grid.Panel.Modal" TargetType="Grid">
         <!--<Setter Property="CompressedLayout.IsHeadless" Value="true" />-->
         <Setter Property="ColumnDefinitions" Value="*,48" />
         <Setter Property="RowDefinitions" Value="Auto,*,Auto" />
     </Style>
 
     <!--  Common style for Shell.TitleView -->
-    <Style x:Key="ShellTitleViewGridStyle" TargetType="Grid">
+    <Style x:Key="Style.Core.Grid.ShellTitleView" TargetType="Grid">
         <!--<Setter Property="HeightRequest" Value="150" />-->
         <!--<Setter Property="Padding" Value="0, 10" />-->
     </Style>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/IndicatorView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/IndicatorView.xaml
@@ -11,10 +11,10 @@
     <!--
     Docs: https://docs.microsoft.com/de-de/dotnet/maui/user-interface/controls/indicatorview
     -->
-    <Style x:Key="DefaultIndicatorViewStyle" TargetType="IndicatorView">
+    <Style x:Key="Style.Core.IndicatorView.Default" TargetType="IndicatorView">
         <Setter Property="IndicatorColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"/>
         <Setter Property="SelectedIndicatorColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}"/>
     </Style>
 
-    <Style TargetType="IndicatorView" BasedOn="{StaticResource DefaultIndicatorViewStyle}" />
+    <Style TargetType="IndicatorView" BasedOn="{StaticResource Style.Core.IndicatorView.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
@@ -15,21 +15,15 @@
     <!-- OPTIMIZED -->
 
     <!-- DEFAULT LABEL STYLE -->
-    <Style x:Key="DefaultLabelStyle" TargetType="Label">
+    <Style x:Key="Style.Core.Label.Default" TargetType="Label">
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
         <Setter Property="FontSize" Value="Default"/>
     </Style>
 
-    <!-- Obsolete, will be removed -->
-    <Style x:Key="LabelStyle" TargetType="Label" BasedOn="{StaticResource DefaultLabelStyle}">
-        <Setter Property="FontSize" Value="Default"/>
-    </Style>
-
-    <!-- ICON ONLY LABELS -->
     <!--  Common style for icon label  -->
-    <Style x:Key="IconLabelStyle" TargetType="Label">
+    <Style x:Key="Style.Core.Label.Icon" TargetType="Label">
         <Setter Property="Margin" Value="16,8" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="FontSize" Value="Medium" />
@@ -39,78 +33,72 @@
     </Style>
 
     <!--  Common style for icon label  -->
-    <Style x:Key="MaterialSettingsIconLabelStyle" TargetType="Label" BasedOn="{StaticResource IconLabelStyle}">
-        <Setter Property="Text" Value="{x:Static icons:MaterialIcons.VectorSquare}" />
-        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-    </Style>
-
-    <Style x:Key="TextInputLayoutMaterialIconLabelStyle" TargetType="Label" BasedOn="{StaticResource MaterialSettingsIconLabelStyle}">
-        <Setter Property="HorizontalTextAlignment" Value="Start" />
-        <Setter Property="Margin" Value="0" />
-    </Style>
-
-    <Style x:Key="MaterialFontFamilyIconLabelStyle" TargetType="Label">
+    <Style x:Key="Style.Core.Label.Icon.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
         <Setter Property="FontSize" Value="Large"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
     </Style>
 
-    <Style x:Key="PrimaryMaterialFontFamilyIconLabelStyle" TargetType="Label" BasedOn="{StaticResource MaterialFontFamilyIconLabelStyle}">
+
+    <Style x:Key="Style.Core.Label.Icon.MaterialDesign.TextInputLayout" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
+        <Setter Property="HorizontalTextAlignment" Value="Start" />
+        <Setter Property="Margin" Value="0" />
+    </Style>
+
+    <Style x:Key="Style.Core.Label.IconPrimary.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}"/>
     </Style>
 
-    <Style x:Key="MediumLabelStyle" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
+    <Style x:Key="Style.Core.Label.Medium" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="FontFamily" Value="{StaticResource MontserratMedium}" />
         <Setter Property="FontSize" Value="Medium" />
         <Setter Property="Margin" Value="16, 12" />
     </Style>
 
-    <Style x:Key="SmallLabelStyle" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
+    <Style x:Key="Style.Core.Label.Small" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}" />
         <Setter Property="FontSize" Value="Small"/>
     </Style>
 
-    <Style x:Key="VerySmallLabelStyle" TargetType="Label" BasedOn="{StaticResource SmallLabelStyle}">
+    <Style x:Key="Style.Core.Label.VerySmall" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
         <Setter Property="FontSize" Value="Micro"/>
     </Style>
 
-    <Style x:Key="SetupLabelStyle" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
+    <Style x:Key="Style.Core.Label.Setup" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
     </Style>
 
-    <Style x:Key="LinkLabelStyle" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
+    <Style x:Key="Style.Core.Label.Link" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="TextColor" Value="{StaticResource Blue}"/>
     </Style>
 
-    <!-- PrimaryColor Label -->
-    <Style x:Key="PrimaryLabelStyle" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
+    <Style x:Key="Style.Core.Label.Primary" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}"/>
     </Style>
 
-    <!-- PrimaryColor Dark Label style -->
-    <Style x:Key="PrimaryDarkLabelStyle" TargetType="Label" BasedOn="{StaticResource PrimaryLabelStyle}">
+    <Style x:Key="Style.Core.Label.PrimaryDark" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Primary}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}"/>
     </Style>
 
     <!-- Warning (on yellow background )-->
-    <Style x:Key="WarningLabelStyle" TargetType="Label" BasedOn="{StaticResource MediumLabelStyle}">
+    <Style x:Key="Style.Core.Label.Warning" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Medium}">
         <Setter Property="TextColor" Value="{StaticResource Black}"/>
         <Setter Property="LineBreakMode" Value="WordWrap"/>
     </Style>
 
     <!-- Error (on red background )-->
-    <Style x:Key="ErrorLabelStyle" TargetType="Label" BasedOn="{StaticResource WarningLabelStyle}">
+    <Style x:Key="Style.Core.Label.Error" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Warning}">
         <Setter Property="TextColor" Value="{StaticResource White}"/>
     </Style>
 
     <!-- Shell Flyout Menu Label -->
-    <Style x:Key="ShellLabelStyle" TargetType="Label" BasedOn="{StaticResource MediumLabelStyle}">
+    <Style x:Key="Style.Core.Label.Shell" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Medium}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
         <Setter Property="FontSize" Value="Default" />
     </Style>
 
-    <Style x:Key="SettingsLabelStyle" TargetType="Label" BasedOn="{StaticResource DefaultLabelStyle}">
+    <Style x:Key="Style.Core.Label.Settings" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="Margin" Value="16,0,0,0" />
         <Setter Property="FontSize" Value="Small" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
@@ -119,7 +107,7 @@
         <Setter Property="VerticalTextAlignment" Value="Center"/>
     </Style>
 
-    <Style x:Key="SettingsSmallLabelStyle" TargetType="Label" BasedOn="{StaticResource SmallLabelStyle}">
+    <Style x:Key="Style.Core.Label.SettingsSmall" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
         <Setter Property="Margin" Value="16,0,0,0" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray700}, Dark={StaticResource Gray300}}"/>
         <Setter Property="VerticalTextAlignment" Value="Center"/>
@@ -127,7 +115,7 @@
 
     <!-- HEADLINES -->
     <!-- Default headline label style -->
-    <Style x:Key="HeadlineLabelStyle" TargetType="Label" BasedOn="{StaticResource DefaultLabelStyle}">
+    <Style x:Key="Style.Core.Label.Headline" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="VerticalTextAlignment" Value="Center"/>
         <Setter Property="HorizontalTextAlignment" Value="Center"/>
         <Setter Property="FontFamily" Value="{StaticResource MontserratBold}" />
@@ -136,23 +124,23 @@
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"/>
     </Style>
 
-    <Style x:Key="PrimaryHeadlineLabelStyle" TargetType="Label" BasedOn="{StaticResource HeadlineLabelStyle}">
+    <Style x:Key="Style.Core.Label.HeadlinePrimary" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Headline}">
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="FontSize" Value="Large" />
     </Style>
 
-    <Style x:Key="TitleViewHeadlineLabelStyle" TargetType="Label" BasedOn="{StaticResource PrimaryHeadlineLabelStyle}">
+    <Style x:Key="Style.Core.Label.TitleView" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.HeadlinePrimary}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}"/>
         <Setter Property="FontSize" Value="Medium" />
     </Style>
 
     <!-- PrimaryColor Dark Headline -->
-    <Style x:Key="PrimaryDarkHeadlineLabelStyle" TargetType="Label" BasedOn="{StaticResource HeadlineLabelStyle}">
+    <Style x:Key="Style.Core.Label.HeadlinePrimaryDark" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Headline}">
         <Setter Property="TextColor" Value="{DynamicResource PrimaryDarkColor}"/>
     </Style>
 
     <!--  Common style for swipe template content button control  -->
-    <Style x:Key="SwipeTemplateButtonStyle" TargetType="Label">
+    <Style x:Key="Style.Core.Label.IconSwipe" TargetType="Label">
         <!-- Check if needed 
         <Setter Property="Background" Value="Transparent" />-->
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
@@ -164,14 +152,13 @@
 
     <!--  Common style for option labels  -->
     <Style
-        x:Key="OptionButtonLabelStyle"
-        BasedOn="{StaticResource LabelStyle}"
+        x:Key="Style.Core.Label.Option"
+        BasedOn="{StaticResource Style.Core.Label.Default}"
         TargetType="Label">
         <Setter Property="HorizontalTextAlignment" Value="Center" />
     </Style>
 
-
-    <Style x:Key="GroupingHeaderLabelStyle" TargetType="Label">
+    <Style x:Key="Style.Core.Label.GroupingHeader" TargetType="Label">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
         <Setter Property="FontSize" Value="{OnIdiom Desktop=Medium, Default=Large}" />
         <Setter Property="VerticalTextAlignment" Value="Center" />
@@ -181,26 +168,23 @@
     </Style>
 
     <!--  Common style for swipe template content button control  -->
-    <Style x:Key="SwipeTemplateMaterialButtonStyle" TargetType="Label" BasedOn="{StaticResource SwipeTemplateButtonStyle}">
+    <Style x:Key="Style.Core.Label.IconSwipe.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.IconSwipe}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
     </Style>
 
-    <Style x:Key="MaterialFontIconSpanStyle" TargetType="Span">
+    <Style x:Key="Style.Core.Span.Icon.MaterialDesign" TargetType="Span">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
         <Setter Property="FontSize" Value="Medium"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}"/>
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
     </Style>
 
-    <Style x:Key="FontIconSpanStyle" TargetType="Span" BasedOn="{StaticResource MaterialFontIconSpanStyle}">
+    <Style x:Key="Style.Core.Span.Icon" TargetType="Span" BasedOn="{StaticResource Style.Core.Span.Icon.MaterialDesign}">
         <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
     </Style>
 
-    <Style x:Key="MaterialFontFamilyIconSmallLabelStyle" TargetType="Label" BasedOn="{StaticResource MaterialFontFamilyIconLabelStyle}">
+    <Style x:Key="Style.Core.Span.IconTiny.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
         <Setter Property="FontSize" Value="Default"/>
     </Style>
 
-    <Style x:Key="MaterialSwipeTemplateButtonStyle" TargetType="Label" BasedOn="{StaticResource SwipeTemplateButtonStyle}">
-        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-    </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ListView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ListView.xaml
@@ -10,11 +10,11 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultListViewStyle" TargetType="ListView">
+
+    <Style x:Key="Style.Core.ListView.Default" TargetType="ListView">
         <Setter Property="SeparatorColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
         <Setter Property="RefreshControlColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
     </Style>
 
-    <Style TargetType="ListView" BasedOn="{StaticResource DefaultListViewStyle}" />
+    <Style TargetType="ListView" BasedOn="{StaticResource Style.Core.ListView.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Page.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Page.xaml
@@ -9,36 +9,44 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style TargetType="Page" ApplyToDerivedTypes="True">
+
+    <Style x:Key="Style.Core.Page.Default" TargetType="Page">
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
-    <Style TargetType="NavigationPage">
+    <Style TargetType="Page" ApplyToDerivedTypes="True" BasedOn="{StaticResource Style.Core.Page.Default}"/>
+
+    <Style x:Key="Style.Core.NavigationPage.Default" TargetType="NavigationPage">
         <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BarTextColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="IconColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
     </Style>
 
-    <Style TargetType="TabbedPage">
+    <Style TargetType="NavigationPage" BasedOn="{StaticResource Style.Core.NavigationPage.Default}" />
+
+    <Style x:Key="Style.Core.TabbedPage.Default" TargetType="TabbedPage">
         <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
         <Setter Property="BarTextColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="UnselectedTabColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
         <Setter Property="SelectedTabColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
     </Style>
 
-    <Style x:Key="DefaultPageStyle" TargetType="ContentPage">
+    <Style TargetType="TabbedPage" BasedOn="{StaticResource Style.Core.TabbedPage.Default}" />
+
+    <Style x:Key="Style.Core.ContentPage.Default" TargetType="ContentPage">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
-    <Style x:Key="ModalPageStyle" TargetType="ContentPage" BasedOn="{StaticResource DefaultPageStyle}">
+    <Style TargetType="ContentPage" BasedOn="{StaticResource Style.Core.ContentPage.Default}" />
+
+    <Style x:Key="Style.Core.ContentPage.Modal" TargetType="ContentPage" BasedOn="{StaticResource Style.Core.ContentPage.Default}">
         <Setter Property="Shell.PresentationMode" Value="ModalAnimated" />
         <Setter Property="ios:Page.ModalPresentationStyle" Value="{OnIdiom Tablet=Automatic, Default=FormSheet}" />
         <!--<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />-->
     </Style>
 
-    <Style x:Key="SettingsPageStyle" TargetType="ContentPage" BasedOn="{StaticResource DefaultPageStyle}">
+    <Style x:Key="Style.Core.ContentPage.Settings" TargetType="ContentPage" BasedOn="{StaticResource Style.Core.ContentPage.Default}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
     </Style>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Picker.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Picker.xaml
@@ -8,8 +8,8 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultPickerStyle" TargetType="Picker">
+
+    <Style x:Key="Style.Core.Picker.Default" TargetType="Picker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
@@ -34,5 +34,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Picker" BasedOn="{StaticResource DefaultPickerStyle}" />
+    <Style TargetType="Picker" BasedOn="{StaticResource Style.Core.Picker.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ProgressBar.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ProgressBar.xaml
@@ -7,8 +7,8 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-   
-    <Style x:Key="DefaultProgressBarStyle" TargetType="ProgressBar">
+
+    <Style x:Key="Style.Core.ProgressBar.Default" TargetType="ProgressBar">
         <Setter Property="ProgressColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -28,5 +28,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="ProgressBar" BasedOn="{StaticResource DefaultProgressBarStyle}" />
+    <Style TargetType="ProgressBar" BasedOn="{StaticResource Style.Core.ProgressBar.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/RadioButton.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/RadioButton.xaml
@@ -8,8 +8,8 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultRadioButtonStyle" TargetType="RadioButton">
+
+    <Style x:Key="Style.Core.RadioButton.Default" TargetType="RadioButton">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="FontSize" Value="Default"/>
@@ -31,5 +31,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="RadioButton" BasedOn="{StaticResource DefaultRadioButtonStyle}" />
+    <Style TargetType="RadioButton" BasedOn="{StaticResource Style.Core.RadioButton.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/RefreshView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/RefreshView.xaml
@@ -7,11 +7,11 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultRefreshViewStyle" TargetType="RefreshView">
+
+    <Style x:Key="Style.Core.RefreshView.Default" TargetType="RefreshView">
         <Setter Property="RefreshColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
         <Setter Property="Background" Value="{AppThemeBinding Light={OnPlatform WinUI={StaticResource White}, Default={StaticResource Gray100}}, Dark={OnPlatform WinUI={StaticResource Black}, Default={StaticResource Gray900}}}" />
     </Style>
 
-    <Style TargetType="RefreshView" BasedOn="{StaticResource DefaultRefreshViewStyle}" />
+    <Style TargetType="RefreshView" BasedOn="{StaticResource Style.Core.RefreshView.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/SearchBar.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/SearchBar.xaml
@@ -9,7 +9,7 @@
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="DefaultSearchBarStyle" TargetType="SearchBar">
+    <Style x:Key="Style.Core.SearchBar.Default" TargetType="SearchBar">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="CancelButtonColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
@@ -35,5 +35,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="SearchBar" BasedOn="{StaticResource DefaultSearchBarStyle}" />
+    <Style TargetType="SearchBar" BasedOn="{StaticResource Style.Core.SearchBar.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/SearchHandler.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/SearchHandler.xaml
@@ -9,7 +9,7 @@
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="DefaultSearchHandlerStyle" TargetType="SearchHandler">
+    <Style x:Key="Style.Core.SearchHandler.Default" TargetType="SearchHandler">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}" />
@@ -34,5 +34,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="SearchHandler" BasedOn="{StaticResource DefaultSearchHandlerStyle}" />
+    <Style TargetType="SearchHandler" BasedOn="{StaticResource Style.Core.SearchHandler.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shell.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Shell.xaml
@@ -29,7 +29,7 @@
     <Style BasedOn="{StaticResource BaseStyle}" TargetType="ShellItem" ApplyToDerivedTypes="True" />
     -->
 
-    <Style x:Key="DefaultShellStyle" TargetType="Shell" ApplyToDerivedTypes="True">
+    <Style x:Key="Style.Core.Shell.Default" TargetType="Shell" ApplyToDerivedTypes="True">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}"/>
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}"/>
         <Setter Property="ForegroundColor" Value="{DynamicResource PrimaryColor}"/>
@@ -56,7 +56,7 @@
         <Setter Property="Shell.TabBarUnselectedColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
     </Style>
 
-    <Style TargetType="Shell" ApplyToDerivedTypes="True" BasedOn="{StaticResource DefaultShellStyle}"/>
+    <Style TargetType="Shell" ApplyToDerivedTypes="True" BasedOn="{StaticResource Style.Core.Shell.Default}"/>
     
     <!--
     <Style x:Key="DefaultShellStyle" TargetType="Shell">
@@ -72,7 +72,7 @@
     </Style>
     -->
 
-    <Style x:Key="DefaultFlyoutItemStyle" TargetType="FlyoutItem">
+    <Style x:Key="Style.Core.FlyoutItem.Default" TargetType="FlyoutItem">
         <Style.Triggers>
             <Trigger TargetType="FlyoutItem" Property="IsEnabled" Value="False">
                 <Setter Property="Icon">
@@ -91,6 +91,6 @@
     </Style>
     
     <!-- Apply default style defaultly-->
-    <Style TargetType="FlyoutItem" BasedOn="{StaticResource DefaultFlyoutItemStyle}"/>
+    <Style TargetType="FlyoutItem" BasedOn="{StaticResource Style.Core.FlyoutItem.Default}"/>
 
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Slider.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Slider.xaml
@@ -8,8 +8,8 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultSliderStyle" TargetType="Slider">
+
+    <Style x:Key="Style.Core.Slider.Default" TargetType="Slider">
         <Setter Property="MinimumTrackColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
         <Setter Property="MaximumTrackColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
         <Setter Property="ThumbColor" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
@@ -35,5 +35,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Slider" BasedOn="{StaticResource DefaultSliderStyle}" />
+    <Style TargetType="Slider" BasedOn="{StaticResource Style.Core.Slider.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/StackLayout.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/StackLayout.xaml
@@ -7,30 +7,30 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="StackLayoutHeaderStyle" TargetType="StackLayout">
+
+    <Style x:Key="Style.Core.StackLayout.Header" TargetType="StackLayout">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
-    <Style x:Key="ModalInputPageStackLayoutStyle" TargetType="StackLayout">
+    <Style x:Key="Style.Core.StackLayout.Modal" TargetType="StackLayout">
         <Setter Property="Margin" Value="{OnIdiom Tablet=16, Default=12}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
 
-    <Style x:Key="VerticalStackLayoutHeaderStyle" TargetType="VerticalStackLayout">
+    <Style x:Key="Style.Core.VerticalStackLayout.Header" TargetType="VerticalStackLayout">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
-    <Style x:Key="VerticalModalInputPageStackLayoutStyle" TargetType="VerticalStackLayout">
+    <Style x:Key="Style.Core.VerticalStackLayout.Modal" TargetType="VerticalStackLayout">
         <Setter Property="Margin" Value="{OnIdiom Tablet=16, Default=12}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
 
-    <Style x:Key="HorizontalStackLayoutHeaderStyle" TargetType="HorizontalStackLayout">
+    <Style x:Key="Style.Core.HorizontalStackLayout.Header" TargetType="HorizontalStackLayout">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>
-    <Style x:Key="HorizontalModalInputPageStackLayoutStyle" TargetType="HorizontalStackLayout">
+    <Style x:Key="Style.Core.HorizontalStackLayout.Modal" TargetType="HorizontalStackLayout">
         <Setter Property="Margin" Value="{OnIdiom Tablet=16, Default=12}" />
         <Setter Property="Padding" Value="4,4,4,4" />
     </Style>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/SwipeItem.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/SwipeItem.xaml
@@ -8,9 +8,9 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="DefaultSwipeItemStyle" TargetType="SwipeItem">
+    <Style x:Key="Style.Core.SwipeItem.Default" TargetType="SwipeItem">
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
     </Style>
 
-    <Style TargetType="SwipeItem" BasedOn="{StaticResource DefaultSwipeItemStyle}" />
+    <Style TargetType="SwipeItem" BasedOn="{StaticResource Style.Core.SwipeItem.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Switch.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Switch.xaml
@@ -7,8 +7,8 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultSwitchStyle" TargetType="Switch">
+
+    <Style x:Key="Style.Core.Switch.Default" TargetType="Switch">
         <Setter Property="VerticalOptions" Value="Center" />
         <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
         <Setter Property="ThumbColor" Value="{StaticResource White}" />
@@ -41,5 +41,5 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Switch" BasedOn="{StaticResource DefaultSwitchStyle}" />
+    <Style TargetType="Switch" BasedOn="{StaticResource Style.Core.Switch.Default}" />
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/TimePicker.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/TimePicker.xaml
@@ -8,8 +8,8 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
-    <Style x:Key="DefaultTimePickerStyle" TargetType="TimePicker">
+
+    <Style x:Key="Style.Core.TimePicker.Default" TargetType="TimePicker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="FontSize" Value="Default"/>
@@ -30,4 +30,6 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
+
+    <Style TargetType="TimePicker" BasedOn="{StaticResource Style.Core.TimePicker.Default}" />
 </ResourceDictionary>


### PR DESCRIPTION
This PR renames all style keys to fit the new syntax. Also the example app has been updated. All `ItemTempaltes` will follow in a separate PR.

Fixed #403