### PR TITLE
Fixed wrong style names

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRangeSlider.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfRangeSlider.xaml
@@ -40,7 +40,7 @@
                                         />
                                 </Setter.Value>
                             </Setter>
-                            <Setter Property="LabelStyle">
+                            <Setter Property="Style.Core.Label.Default">
                                 <Setter.Value>
                                     <sliders:SliderLabelStyle
                                         ActiveTextColor = "{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
@@ -74,7 +74,7 @@
                                         />
                                 </Setter.Value>
                             </Setter>
-                            <Setter Property="LabelStyle">
+                            <Setter Property="Style.Core.Label.Default">
                                 <Setter.Value>
                                     <sliders:SliderLabelStyle
                                         ActiveTextColor = "{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTabView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfTabView.xaml
@@ -42,7 +42,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialIconSfTabViewItemStyle" TargetType="tabView:SfTabItem" BasedOn="{StaticResource Style.Syncfusion.SfTabItem.Default}">
+    <Style x:Key="Style.Syncfusion.SfTabItem.Icon.MaterialDesign" TargetType="tabView:SfTabItem" BasedOn="{StaticResource Style.Syncfusion.SfTabItem.Default}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}"/>
         <Setter Property="FontSize" Value="{OnPlatform Android=Default, Default=Small}"/>
     </Style>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -17,13 +17,13 @@
     <DataTemplate x:Key="GroupHeaderSyncfusionTemplate">
         <ViewCell>
             <StackLayout 
-                Style="{StaticResource StackLayoutHeaderStyle}" 
+                Style="{StaticResource Style.Core.StackLayout.Header}" 
                 Orientation="Horizontal"
                 >
                 <!-- Icon -->
                 <Label Margin="10,4">
                     <Label.Style>
-                        <Style TargetType="Label" BasedOn="{StaticResource IconLabelStyle}">
+                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
                             <Setter Property="Text" Value="{x:Static iconsSyncfusion:SyncfusionIcons.Dropdown}"/>
                             <Style.Triggers>
                                 <DataTrigger TargetType="Label" Binding="{Binding IsExpand}" Value="True">
@@ -36,7 +36,7 @@
 
                 <Label 
                     Text="{Binding Key}" 
-                    Style="{StaticResource GroupingHeaderLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.GroupingHeader}"
                     FontAttributes="Bold"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Start"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -27,12 +27,12 @@
                 >
                 <!-- Check icon -->
                 <Border
-                    Style="{StaticResource ProfileBorderStyle}"
+                    Style="{StaticResource Style.Core.Border.Profile}"
                     Background="{StaticResource LightGreen}"
                     Margin="0"
                     >
                     <Label 
-                        Style="{StaticResource IconLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.Icon}"
                         Text="{x:Static iconsSyncfusion:SyncfusionIcons.Sent}"
                         TextColor="{StaticResource White}"
                         />
@@ -41,7 +41,7 @@
                 <Label 
                     Grid.Column="1"
                     Text="{Binding Feature}"
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Start"
                     />
@@ -66,7 +66,7 @@
                     VerticalTextAlignment="Center"
                     >
                     <Label.Style>
-                        <Style TargetType="Label" BasedOn="{StaticResource MaterialSettingsIconLabelStyle}">
+                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
                             <Setter Property="Text" Value="{x:Static icons:MaterialIcons.AlertCircleOutline}"/>
                             <Style.Triggers>
                                 <!-- Info -->
@@ -101,7 +101,7 @@
                     >
                     <Label 
                         LineBreakMode="WordWrap" 
-                        Style="{StaticResource LabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Default}" 
                         Text="{Binding Message}"
                         FontAttributes="Bold"
                         VerticalTextAlignment="Center"
@@ -112,7 +112,7 @@
                         VerticalTextAlignment="Center"
                         >
                         <Label.Style>
-                            <Style TargetType="Label" BasedOn="{StaticResource SmallLabelStyle}">
+                            <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
                                 <Setter Property="IsVisible" Value="True"/>
                                 <Style.Triggers>
                                     <!-- Has no args -->
@@ -155,12 +155,12 @@
                     <!-- Language name -->
                     <Label 
                         LineBreakMode="NoWrap" 
-                        Style="{StaticResource PrimaryLabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Primary}" 
                         Text="{Binding Name}"
                         />
                     <!-- Translator -->
                     <Label 
-                        Style="{StaticResource LabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Default}" 
                         LineBreakMode="WordWrap" 
                         Text="{Binding Translator}"
                         FontSize="12"
@@ -198,13 +198,13 @@
                     <!-- Language name -->
                     <Label 
                         LineBreakMode="NoWrap" 
-                        Style="{StaticResource PrimaryLabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Primary}" 
                         TextColor="{StaticResource White}"
                         Text="{Binding Name}"
                         />
                     <!-- Translator -->
                     <Label 
-                        Style="{StaticResource LabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Default}" 
                         LineBreakMode="WordWrap" 
                         Text="{Binding Translator}"
                         TextColor="{StaticResource White}"
@@ -226,19 +226,19 @@
                 ColumnDefinitions="*,Auto"
                 >
                 <Label
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     LineBreakMode="WordWrap"
                     Text="{Binding Changelog}"
                     />
                 <Border 
                     Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
-                    Style="{StaticResource ProfileBorderStyle}"
+                    Style="{StaticResource Style.Core.Border.Profile}"
                     Grid.Column="1"
                     VerticalOptions="Center"
                     >
                     <Label
                         Margin="4"
-                        Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                         Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
                         VerticalTextAlignment="Center"
                         HorizontalTextAlignment="Center"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -21,7 +21,7 @@
 
     <DataTemplate x:Key="DeleteGestureSwipeTemplate">
         <Label
-            Style="{StaticResource IconLabelStyle}"
+            Style="{StaticResource Style.Core.Label.Icon}"
             Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
             TextColor="{StaticResource White}"
             VerticalTextAlignment="Center"
@@ -44,7 +44,7 @@
             Background="{StaticResource Green}"
             >
             <Label
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                 TextColor="{StaticResource White}"
                 Background="{StaticResource Green}"
@@ -68,7 +68,7 @@
             Background="{StaticResource Blue}"
             >
             <Label
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
                 TextColor="{StaticResource White}"
                 Background="{StaticResource Blue}"
@@ -89,7 +89,7 @@
 
     <DataTemplate x:Key="PrintGestureSwipeTemplate">
         <Label
-            Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+            Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
             Text="{x:Static icons:MaterialIcons.Printer3dNozzleOutline}"
             TextColor="{StaticResource White}"
             VerticalTextAlignment="Center"
@@ -109,7 +109,7 @@
 
     <DataTemplate x:Key="ExecuteGestureSwipeTemplate">
         <Label
-            Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+            Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
             Text="{x:Static icons:MaterialIcons.RunFast}"
             TextColor="{StaticResource White}"
             VerticalTextAlignment="Center"
@@ -133,7 +133,7 @@
                 ColumnDefinitions="*,*"
                 >
                 <Label
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                     TextColor="{StaticResource White}"
                     Background="{StaticResource Red}"
@@ -151,7 +151,7 @@
                 </Label>
                 <Label
                     Grid.Column="1"
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                     TextColor="{StaticResource White}"
                     Background="{StaticResource Green}"
@@ -175,7 +175,7 @@
                 ColumnDefinitions="*,*"
                 >
                 <Label
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.FileExplorer}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
@@ -194,7 +194,7 @@
 
                 <Label
                     Grid.Column="1"
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
@@ -218,7 +218,7 @@
             ColumnDefinitions="*,*,*"
             >
             <Label
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
@@ -236,7 +236,7 @@
             </Label>
             <Label
                     Grid.Column="1"
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
@@ -254,7 +254,7 @@
             </Label>
             <Label
                 Grid.Column="2"
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Viewed}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -278,7 +278,7 @@
             ColumnDefinitions="*,*"
             >
             <Label
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -296,7 +296,7 @@
             </Label>
             <Label
                 Grid.Column="1"
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -320,7 +320,7 @@
             ColumnDefinitions="*,*"
             >
             <Label
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -338,7 +338,7 @@
             </Label>
             <Label
                 Grid.Column="1"
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -362,7 +362,7 @@
             ColumnDefinitions="*,*,*"
             >
             <Label
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -380,7 +380,7 @@
             </Label>
             <Label
                 Grid.Column="1"
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -398,7 +398,7 @@
             </Label>
             <Label
                 Grid.Column="2"
-                Style="{StaticResource IconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon}"
                 Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -422,7 +422,7 @@
             ColumnDefinitions="*,*"
             >
             <Label
-                Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                 Text="{x:Static icons:MaterialIcons.Printer3dNozzleOutline}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -440,7 +440,7 @@
             </Label>
             <Label
                 Grid.Column="1"
-                Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                 Text="{x:Static icons:MaterialIcons.EyeOutline}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -464,7 +464,7 @@
             ColumnDefinitions="*,*"
             >
             <Label
-                Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                 Text="{x:Static icons:MaterialIcons.RunFast}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -482,7 +482,7 @@
             </Label>
             <Label
                 Grid.Column="1"
-                Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                 Text="{x:Static icons:MaterialIcons.PencilOutline}"
                 TextColor="{StaticResource White}"
                 VerticalTextAlignment="Center"
@@ -507,7 +507,7 @@
                 ColumnDefinitions="*,*,*"
                 >
                 <Label
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Viewed}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
@@ -525,7 +525,7 @@
                 </Label>
                 <Label
                     Grid.Column="1"
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"
@@ -543,7 +543,7 @@
                 </Label>
                 <Label
                     Grid.Column="2"
-                    Style="{StaticResource IconLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Icon}"
                     Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
                     TextColor="{StaticResource White}"
                     VerticalTextAlignment="Center"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -131,7 +131,7 @@
         <Setter Property="FontSize" Value="{OnIdiom Desktop=Medium, Default=Large}" />
     </Style>
 
-    <Style x:Key="Style.Core.Button.IconPrimary.MaterialDesign" TargetType="Button" BasedOn="{StaticResource MaterialDesignStyle.Core.Button.Icon}">
+    <Style x:Key="Style.Core.Button.IconPrimary.MaterialDesign" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
         <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -179,7 +179,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="Style.Core.Button.LinkRound" TargetType="Button" BasedOn="{StaticResource LinkButtonStyle}">
+    <Style x:Key="Style.Core.Button.LinkRound" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Link}">
         <Setter Property="BorderColor" Value="{StaticResource Blue}" />
         <Setter Property="BorderWidth" Value="2" />
         <Setter Property="HeightRequest" Value="50" />
@@ -233,7 +233,7 @@
         <Setter Property="CornerRadius" Value="{OnIdiom Desktop=32, Tablet=32, Default=25}" />
     </Style>
 
-    <Style x:Key="Style.Core.Button.IconRound.EmergencyStop" TargetType="Button" BasedOn="{StaticResource RoundMaterialDesignStyle.Core.Button.Icon}">
+    <Style x:Key="Style.Core.Button.IconRound.EmergencyStop" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
         <Setter Property="Background" Value="{StaticResource Red}" />
         <Setter Property="BorderColor" Value="{StaticResource Yellow}" />
         <Setter Property="TextColor" Value="{StaticResource White}" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Entry.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Entry.xaml
@@ -63,7 +63,7 @@
     </Style>
 
     <Style TargetType="Entry" BasedOn="{StaticResource Style.Core.Entry.Default}" ApplyToDerivedTypes="True"/>
-    <Style TargetType="control:BorderlessEntry" BasedOn="{StaticResource DefaultEntryStyle}" ApplyToDerivedTypes="True"/>
+    <Style TargetType="control:BorderlessEntry" BasedOn="{StaticResource Style.Core.BorderlessEntry.Default}" ApplyToDerivedTypes="True"/>
 
     <Style x:Key="Style.Core.Entry.Numeric" TargetType="Entry" BasedOn="{StaticResource Style.Core.Entry.Default}">
         <Setter Property="Keyboard" Value="Numeric"/>
@@ -73,7 +73,7 @@
         <Setter Property="Keyboard" Value="Numeric"/>
     </Style>
 
-    <Style x:Key="Style.Core.Entry.Password" TargetType="Entry" BasedOn="{StaticResource DefaultEntryStyle}">
+    <Style x:Key="Style.Core.Entry.Password" TargetType="Entry" BasedOn="{StaticResource Style.Core.Entry.Default}">
         <Setter Property="IsPassword" Value="True"/>
         <Setter Property="IsSpellCheckEnabled" Value="False" />
     </Style>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Frame.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Frame.xaml
@@ -16,7 +16,7 @@
 
     <Style TargetType="Frame" BasedOn="{StaticResource Style.Core.Frame.Default}" />
 
-    <Style x:Key="Style.Core.Frame.ListViewItem" TargetType="Frame" BasedOn="{StaticResource DefaultFrameStyle}" >
+    <Style x:Key="Style.Core.Frame.ListViewItem" TargetType="Frame" BasedOn="{StaticResource Style.Core.Frame.Default}" >
         <Setter Property="BorderColor" Value="{StaticResource Transparent}"/>
         <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Light_ItemTemplateBorder}, Dark={StaticResource Dark_ItemTemplateBorder}}" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
@@ -40,8 +40,12 @@
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
     </Style>
 
+    <Style x:Key="Style.Core.Label.IconSettings.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
+        <Setter Property="Text" Value="{x:Static icons:MaterialIcons.VectorSquare}" />
+        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
+    </Style>
 
-    <Style x:Key="Style.Core.Label.Icon.MaterialDesign.TextInputLayout" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
+    <Style x:Key="Style.Core.Label.Icon.MaterialDesign.TextInputLayout" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.IconSettings.MaterialDesign}">
         <Setter Property="HorizontalTextAlignment" Value="Start" />
         <Setter Property="Margin" Value="0" />
     </Style>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/CarouselViewItemTemplates.xaml
@@ -60,7 +60,7 @@
                     >
                     <Label
                         Text="{Binding ThemeName}"
-                        Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                         TextColor="{Binding PrimaryColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
                         VerticalTextAlignment="Center"
                         HorizontalTextAlignment="Center"
@@ -78,7 +78,7 @@
                             >
                             <Label
                                 Text="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToStringConverter}}"
-                                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                                Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                                 TextColor="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
                                 VerticalTextAlignment="Center"
                                 HorizontalTextAlignment="Center"
@@ -93,7 +93,7 @@
                             >
                             <Label
                                 Text="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToStringConverter}}"
-                                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                                Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                                 TextColor="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
                                 VerticalTextAlignment="Center"
                                 HorizontalTextAlignment="Center"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
@@ -40,7 +40,7 @@
             <Label 
                 Grid.Row="1"
                 Text="{Binding Heading}"
-                Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                 VerticalTextAlignment="End"
                 HorizontalTextAlignment="Center"
                 SemanticProperties.HeadingLevel="Level1"
@@ -49,7 +49,7 @@
 
             <Label
                 Grid.Row="2"
-                Style="{StaticResource LabelStyle}"
+                Style="{StaticResource Style.Core.Label.Default}"
                 Text="{Binding Content}"
                 VerticalTextAlignment="Center"
                 HorizontalTextAlignment="Center"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -17,13 +17,13 @@
     <DataTemplate x:Key="GroupHeaderTemplate">
         <ViewCell>
             <StackLayout 
-                Style="{StaticResource StackLayoutHeaderStyle}" 
+                Style="{StaticResource Style.Core.StackLayout.Header}" 
                 Orientation="Horizontal"
                 >
                 <!-- Icon -->
                 <Label Margin="10,4">
                     <Label.Style>
-                        <Style TargetType="Label" BasedOn="{StaticResource MaterialFontFamilyIconLabelStyle}">
+                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
                             <Setter Property="Text" Value="{x:Static icons:MaterialIcons.ArrowDown}"/>
                             <Style.Triggers>
                                 <DataTrigger TargetType="Label" Binding="{Binding IsExpand}" Value="True">
@@ -36,7 +36,7 @@
 
                 <Label 
                     Text="{Binding Key}" 
-                    Style="{StaticResource GroupingHeaderLabelStyle}"
+                    Style="{StaticResource Style.Core.Label.GroupingHeader}"
                     FontAttributes="Bold"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Start"

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -24,12 +24,12 @@
                 >
                 <!-- Check icon -->
                 <Border
-                    Style="{StaticResource ProfileBorderStyle}"
+                    Style="{StaticResource Style.Core.Border.Profile}"
                     Background="{StaticResource LightGreen}"
                     Margin="0"
                     >
                     <Label 
-                        Style="{StaticResource IconLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                         Text="{x:Static icons:MaterialIcons.Check}"
                         TextColor="{StaticResource White}"
                         />
@@ -38,7 +38,7 @@
                 <Label 
                     Grid.Column="1"
                     Text="{Binding Feature}"
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     VerticalTextAlignment="Center"
                     HorizontalTextAlignment="Start"
                     />
@@ -63,7 +63,7 @@
                     VerticalTextAlignment="Center"
                     >
                     <Label.Style>
-                        <Style TargetType="Label" BasedOn="{StaticResource MaterialSettingsIconLabelStyle}">
+                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
                             <Setter Property="Text" Value="{x:Static icons:MaterialIcons.AlertCircleOutline}"/>
                             <Style.Triggers>
                                 <!-- Info -->
@@ -98,7 +98,7 @@
                     >
                     <Label 
                         LineBreakMode="WordWrap" 
-                        Style="{StaticResource SmallLabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Small}" 
                         Text="{Binding Message}"
                         FontAttributes="Bold"
                         VerticalTextAlignment="Center"
@@ -109,7 +109,7 @@
                         VerticalTextAlignment="Center"
                         >
                         <Label.Style>
-                            <Style TargetType="Label" BasedOn="{StaticResource SmallLabelStyle}">
+                            <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
                                 <Setter Property="IsVisible" Value="True"/>
                                 <Style.Triggers>
                                     <!-- Has no args -->
@@ -152,12 +152,12 @@
                     <!-- Language name -->
                     <Label 
                         LineBreakMode="NoWrap" 
-                        Style="{StaticResource PrimaryLabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Primary}" 
                         Text="{Binding Name}"
                         />
                     <!-- Translator -->
                     <Label 
-                        Style="{StaticResource LabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Default}" 
                         LineBreakMode="WordWrap" 
                         Text="{Binding Translator}"
                         FontSize="12"
@@ -195,13 +195,13 @@
                     <!-- Language name -->
                     <Label 
                         LineBreakMode="NoWrap" 
-                        Style="{StaticResource PrimaryLabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Primary}" 
                         TextColor="{StaticResource White}"
                         Text="{Binding Name}"
                         />
                     <!-- Translator -->
                     <Label 
-                        Style="{StaticResource LabelStyle}" 
+                        Style="{StaticResource Style.Core.Label.Default}" 
                         LineBreakMode="WordWrap" 
                         Text="{Binding Translator}"
                         TextColor="{StaticResource White}"
@@ -223,19 +223,19 @@
                 ColumnDefinitions="*,Auto"
                 >
                 <Label
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     LineBreakMode="WordWrap"
                     Text="{Binding Changelog}"
                     />
                 <Border 
                     Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
-                    Style="{StaticResource ProfileBorderStyle}"
+                    Style="{StaticResource Style.Core.Border.Profile}"
                     Grid.Column="1"
                     VerticalOptions="Center"
                     >
                     <Label
                         Margin="4"
-                        Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                         Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
                         VerticalTextAlignment="Center"
                         HorizontalTextAlignment="Center"
@@ -255,19 +255,19 @@
                 ColumnDefinitions="*,Auto"
                 >
                 <Label
-                    Style="{StaticResource LabelStyle}"
+                    Style="{StaticResource Style.Core.Label.Default}"
                     LineBreakMode="WordWrap"
                     Text="{Binding Changelog}"
                     />
                 <Border 
                     Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
-                    Style="{StaticResource ProfileBorderStyle}"
+                    Style="{StaticResource Style.Core.Border.Profile}"
                     Grid.Column="1"
                     VerticalOptions="Center"
                     >
                     <Label
                         Margin="4"
-                        Style="{StaticResource MaterialFontFamilyIconLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
                         Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
                         VerticalTextAlignment="Center"
                         HorizontalTextAlignment="Center"
@@ -298,7 +298,7 @@
                     >
                     <Label
                         Text="{Binding ThemeName}"
-                        Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                         TextColor="{Binding PrimaryColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
                         VerticalTextAlignment="Center"
                         HorizontalTextAlignment="Center"
@@ -316,7 +316,7 @@
                         >
                         <Label
                             Text="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToStringConverter}}"
-                            Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                            Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                             TextColor="{Binding PrimaryLigtherColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
                             VerticalTextAlignment="Center"
                             HorizontalTextAlignment="Center"
@@ -331,7 +331,7 @@
                         >
                         <Label
                             Text="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToStringConverter}}"
-                            Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                            Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                             TextColor="{Binding PrimaryDarkerColor, Converter={StaticResource ColorToBlackWhiteConverter}}"
                             VerticalTextAlignment="Center"
                             HorizontalTextAlignment="Center"
@@ -364,7 +364,7 @@
                     ColumnDefinitions="2*,*,*,*"
                     >
                     <Label
-                        Style="{StaticResource PrimaryHeadlineLabelStyle}"
+                        Style="{StaticResource Style.Core.Label.HeadlinePrimary}"
                         TextColor="{Binding Color, Converter={StaticResource ColorToBlackWhiteConverter}}"
                         VerticalTextAlignment="Center"
                         HorizontalTextAlignment="Center"
@@ -377,7 +377,7 @@
                         >
                         <Label
                             Text="{Binding Name}"
-                            Style="{StaticResource SmallLabelStyle}"
+                            Style="{StaticResource Style.Core.Label.Small}"
                             TextColor="{Binding Color, Converter={StaticResource ColorToBlackWhiteConverter}}"
                             VerticalTextAlignment="Center"
                             HorizontalTextAlignment="Center"
@@ -385,7 +385,7 @@
                             />
                         <Label
                             Text="{Binding Color, Converter={StaticResource ColorToStringConverter}}"
-                            Style="{StaticResource MediumLabelStyle}"
+                            Style="{StaticResource Style.Core.Label.Medium}"
                             TextColor="{Binding Color, Converter={StaticResource ColorToBlackWhiteConverter}}"
                             VerticalTextAlignment="Center"
                             HorizontalTextAlignment="Center"


### PR DESCRIPTION
This PR updates the forgotten and wrong style name keys in the `ItemTemplates` and in some styles.

Fixed #410