### PR TITLE
Throw error on non compiled bindings

### DIFF
--- a/common.props
+++ b/common.props
@@ -18,6 +18,11 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
+		
+		<!-- Warnings as error -->
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<!-- https://github.com/dotnet/maui/pull/19360 -->
+	    <WarningsAsErrors>XC0022,XC0023</WarningsAsErrors>
     </PropertyGroup>
 
 <!--

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Services/ServiceExtensions.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Services/ServiceExtensions.cs
@@ -8,8 +8,8 @@
         public static TService GetService<TService>()
             => Current.GetService<TService>();
 
-        public static IServiceProvider Current
-            =>
+        public static IServiceProvider Current => IPlatformApplication.Current.Services;
+        /*
 #if WINDOWS10_0_17763_0_OR_GREATER
             MauiWinUIApplication.Current.Services;
 #elif ANDROID
@@ -19,5 +19,6 @@
 #else
             null;
 #endif
+        */
     }
 }


### PR DESCRIPTION
This PR handlse `XC0022 and XC0023` as error instead of a warning.

Fixed #429