### PR TITLE
Updated all `nugets` and disabled `TreatWarningsAsErrors`

### DIFF
--- a/common.props
+++ b/common.props
@@ -20,7 +20,7 @@
         <IncludeSymbols>true</IncludeSymbols>
 		
 		<!-- Warnings as error -->
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
 		<!-- https://github.com/dotnet/maui/pull/19360 -->
 	    <WarningsAsErrors>XC0022,XC0023</WarningsAsErrors>
     </PropertyGroup>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/MauiProgram.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/MauiProgram.cs
@@ -1,5 +1,6 @@
 ﻿using AndreasReitberger.Shared.Hosting;
 using AndreasReitberger.Shared.Syncfusion.Hosting;
+using CommunityToolkit.Maui;
 using Microsoft.Extensions.Logging;
 using SharedMauiXamlStylesLibrary.SampleApp.Hosting;
 using Syncfusion.Maui.Core.Hosting;
@@ -13,6 +14,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
+                .UseMauiCommunityToolkit()
                 .ConfigureSyncfusionCore()
                 .InitializeSharedMauiStyles()
                 .InitializeSharedSyncfusionStyles()

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -96,7 +96,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.6" />
-	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
+	  <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.7" />
+	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />
 	</ItemGroup>
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -5,12 +5,16 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Syncfusion.Themes.ItemTemplates.ListViewGroupHeaderTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
 
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"
     xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    
+    xmlns:listView="clr-namespace:Syncfusion.Maui.ListView;assembly=Syncfusion.Maui.ListView"
+    xmlns:data="clr-namespace:Syncfusion.Maui.DataSource;assembly=Syncfusion.Maui.DataSource"
     >
     <converters:UriToStringConverter x:Key="UriToStringConverter" />
 

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -5,9 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Syncfusion.Themes.ItemTemplates.ListViewItemTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"  
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"   
     
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -4,10 +4,10 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Syncfusion.Themes.ItemTemplates.ListViewSwipeTemplates"
-    
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"
+      
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"
     

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -55,19 +55,19 @@
 	
 	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-	  <PackageReference Include="Syncfusion.Maui.Buttons" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Core" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Expander" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.ListView" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Picker" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.TabView" Version="24.2.4" />
-	  <PackageReference Include="Syncfusion.Maui.TreeView" Version="24.2.4" />
+	  <PackageReference Include="Syncfusion.Maui.Buttons" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Core" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Expander" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.ListView" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Picker" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.TabView" Version="24.2.5" />
+	  <PackageReference Include="Syncfusion.Maui.TreeView" Version="24.2.5" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -133,8 +133,8 @@
 
 	<ItemGroup>
 	  <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-	  <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.6" />
-	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
+	  <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.7" />
+	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />
 	  <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
 	</ItemGroup>
 

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
@@ -5,9 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Themes.ItemTemplates.GeneralItemTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
     
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"    
     >

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -7,9 +7,9 @@
     
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
     >
     <converters:UriToStringConverter x:Key="UriToStringConverter" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -5,10 +5,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Themes.ItemTemplates.ListViewItemTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
     xmlns:theme="clr-namespace:AndreasReitberger.Shared.Core.Theme;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"  
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"   
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons"
     >

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ShellItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ShellItemTemplates.xaml
@@ -5,9 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Themes.ItemTemplates.ShellItemTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"
+    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedNetCoreLibrary"
+    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedNetCoreLibrary"
+    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedNetCoreLibrary"
     
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"    
     >

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.1" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.2" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -107,8 +107,8 @@
 	
 	<ItemGroup>
 	  <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-	  <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.6" />
-	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
+	  <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.7" />
+	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />
 	  <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates all nugets to their latest version. Also the `TreatWarningsAsErrors` has been disabled again.

Fixed #431