### PR TITLE
Moved styles using `UIFontIcons` to Syncfusion

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/Core/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/Core/Button.xaml
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    
+    xmlns:shared="clr-namespace:AndreasReitberger.Shared;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:themes="clr-namespace:AndreasReitberger.Shared.Themes.ItemTemplates;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
+    >
+    <!--
+    Important notes:
+    - Always set the `Background` or `BackgroundColor` property before setting the `TextColor` property!
+    - If using `BackgroundColor`. use the `Color...` converters, otherwise the `Brush...` converters
+    -->
+    <ResourceDictionary.MergedDictionaries>
+        <shared:Colors />
+        <shared:Styles />
+        <shared:FontSizes />
+        <shared:Fonts />
+        <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <converters:ColorToLightForgroundConverter x:Key="ColorToLightForgroundConverter"  />
+    <converters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
+
+    <Style x:Key="Style.Core.Button.Icon" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
+        <Setter Property="FontSize" Value="{StaticResource LargeIconSize}" />
+        <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
+        <Setter Property="WidthRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
+        <Setter Property="BorderWidth" Value="0" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{StaticResource Transparent}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style x:Key="Style.Core.Button.IconPrimary" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style x:Key="Style.Core.Button.IconRound" BasedOn="{StaticResource Style.Core.Button.Icon}" TargetType="Button">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="HeightRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
+        <Setter Property="WidthRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
+        <Setter Property="CornerRadius" Value="{OnIdiom Desktop=32, Tablet=32, Default=25}" />
+    </Style>
+
+    <Style x:Key="Style.Core.Button.Swipe" TargetType="Button">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
+        <Setter Property="HeightRequest" Value="32" />
+        <Setter Property="WidthRequest" Value="32" />
+        <Setter Property="BorderWidth" Value="0" />
+        <Setter Property="CornerRadius" Value="16" />
+    </Style>
+    
+</ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/Core/Label.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/Core/Label.xaml
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    
+    xmlns:shared="clr-namespace:AndreasReitberger.Shared;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:themes="clr-namespace:AndreasReitberger.Shared.Themes.ItemTemplates;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
+    >
+    <ResourceDictionary.MergedDictionaries>
+        <shared:Colors />
+        <shared:Styles />
+        <shared:FontSizes />
+        <shared:Fonts />
+        <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <converters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
+
+    <Style x:Key="Style.Core.Label.Icon" TargetType="Label">
+        <Setter Property="Margin" Value="16,8" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+        <Setter Property="FontSize" Value="{StaticResource DefaultIconSize}" />
+        <Setter Property="HorizontalTextAlignment" Value="Center" />
+        <Setter Property="VerticalTextAlignment" Value="Center" />
+        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
+    </Style>
+
+    <Style x:Key="Style.Core.Label.IconHeader" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="HorizontalTextAlignment" Value="Center" />
+        <Setter Property="VerticalTextAlignment" Value="Center" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style x:Key="Style.Core.Label.Medium" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
+        <Setter Property="FontFamily" Value="{StaticResource MontserratMedium}" />
+        <Setter Property="FontSize" Value="{StaticResource MediumTextSize}" />
+        <Setter Property="Margin" Value="16, 12" />
+    </Style>
+
+    <Style x:Key="Style.Core.Label.IconSwipe" TargetType="Label">
+        <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
+        <Setter Property="HorizontalTextAlignment" Value="Center" />
+        <Setter Property="VerticalTextAlignment" Value="Center" />
+        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
+        <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
+    </Style>
+
+    <Style x:Key="Style.Core.Span.Icon" TargetType="Span" BasedOn="{StaticResource Style.Core.Span.Default}">
+        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
+    </Style>
+
+</ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/SharedStyles.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/SharedStyles.xaml
@@ -5,7 +5,9 @@
     x:Class="AndreasReitberger.Shared.Syncfusion.Styles"
     >
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="/Resources/Themes/Controls/Core/Button.xaml" />
         <ResourceDictionary Source="/Resources/Themes/Controls/Core/EnhancedListView.xaml" />
+        <ResourceDictionary Source="/Resources/Themes/Controls/Core/Label.xaml" />
         
         <ResourceDictionary Source="/Resources/Themes/Controls/SfAccordion.xaml" />
         <ResourceDictionary Source="/Resources/Themes/Controls/SfAutoComplete.xaml" />

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -115,6 +115,12 @@
 	  <MauiXaml Update="ContentViews\SortFilterHeaderConventView.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Resources\Themes\Controls\Core\Button.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Resources\Themes\Controls\Core\Label.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Resources\Themes\Controls\SfBarcodeGenerator.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -27,7 +27,6 @@
         <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
         <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
-        <!--<Setter Property="FontSize" Value="Small" />-->
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
         <Setter Property="MinimumHeightRequest" Value="50" />
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -103,13 +102,11 @@
 
     <Style TargetType="ImageButton" BasedOn="{StaticResource Style.Core.ImageButton.Default}"/>
 
-    <Style x:Key="Style.Core.Button.Icon" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
+    <Style x:Key="Style.Core.Button.Icon.MaterialDesign" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
+        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
+        <Setter Property="FontSize" Value="{StaticResource LargeIconSize}" />
         <Setter Property="Background" Value="{StaticResource Transparent}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=Medium, Default=Large}" />-->
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=18, Default=16}" />-->
-        <Setter Property="FontSize" Value="{StaticResource LargeIconSize}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
         <Setter Property="WidthRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
         <Setter Property="BorderWidth" Value="0" />
@@ -134,42 +131,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="Style.Core.Button.IconPrimary" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
-        <!--
-        <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
-        <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
-        -->
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal">
-                        <VisualState.Setters>
-                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}" />
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="PointerOver" />
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style x:Key="Style.Core.Button.Icon.MaterialDesign" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
-        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=Medium, Default=Large}" />-->
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=18, Default=16}" />-->
-        <Setter Property="FontSize" Value="{StaticResource LargeIconSize}" />
-    </Style>
-
     <Style x:Key="Style.Core.Button.IconSmall.MaterialDesign" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon.MaterialDesign}">
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=Small, Default=Default}" /> -->
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=9, Default=Default}" />-->
         <Setter Property="FontSize" Value="{StaticResource SmallTextSize}" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=48, Tablet=48, Default=40}" />
         <Setter Property="WidthRequest" Value="{OnIdiom Desktop=48, Tablet=48, Default=40}" />
@@ -232,21 +194,26 @@
         <Setter Property="CornerRadius" Value="25" />
     </Style>
 
-    <Style x:Key="Style.Core.Button.IconRound" BasedOn="{StaticResource Style.Core.Button.Icon}" TargetType="Button">
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
-        <Setter Property="BorderWidth" Value="1" />
-        <Setter Property="CornerRadius" Value="25" />
-        <Setter Property="WidthRequest" Value="50" />
-        <Setter Property="HeightRequest" Value="50" />
+    <Style x:Key="Style.Core.Button.IconRound.MaterialDesign" BasedOn="{StaticResource Style.Core.Button.Icon.MaterialDesign}" TargetType="Button">
+        <Setter Property="FontSize" Value="{StaticResource LargeTextSize}" />
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray700}}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="HeightRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
+        <Setter Property="WidthRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
+        <Setter Property="CornerRadius" Value="{OnIdiom Desktop=32, Tablet=32, Default=25}" />
     </Style>
 
+    <Style x:Key="Style.Core.Button.IconRound.MaterialDesign.Transparent" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.IconRound.MaterialDesign}">
+        <Setter Property="Background" Value="{StaticResource Transparent}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
+    </Style>
+    
     <Style x:Key="Style.Core.Button.RoundedLong" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Default}">
-        <Setter Property="Margin" Value="20" />
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
-        <!--<Setter Property="FontSize" Value="Small" />-->
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
+        <Setter Property="Margin" Value="20" />
         <Setter Property="FontAttributes" Value="Bold" />
         <Setter Property="HeightRequest" Value="{OnIdiom Desktop=60, Tablet=60, Default=50}" />
         <Setter Property="CornerRadius" Value="{OnIdiom Desktop=30, Tablet=30, Default=20}" />
@@ -259,28 +226,7 @@
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}"/>
     </Style>
 
-    <!--  Common style for swipe template content border control  -->
-    <Style x:Key="Style.Core.Button.Swipe" TargetType="Button">
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
-        <Setter Property="HeightRequest" Value="32" />
-        <Setter Property="WidthRequest" Value="32" />
-        <Setter Property="BorderWidth" Value="0" />
-        <Setter Property="CornerRadius" Value="16" />
-    </Style>
-
-    <Style x:Key="Style.Core.Button.IconRound.MaterialDesign" TargetType="Button">
-        <Setter Property="Background" Value="{StaticResource Transparent}" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-        <Setter Property="FontSize" Value="{StaticResource LargeTextSize}" />
-        <Setter Property="HeightRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
-        <Setter Property="WidthRequest" Value="{OnIdiom Desktop=64, Tablet=64, Default=50}" />
-        <Setter Property="CornerRadius" Value="{OnIdiom Desktop=32, Tablet=32, Default=25}" />
-    </Style>
-
-    <Style x:Key="Style.Core.Button.IconRound.EmergencyStop" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon}">
+    <Style x:Key="Style.Core.Button.IconRound.EmergencyStop" TargetType="Button" BasedOn="{StaticResource Style.Core.Button.Icon.MaterialDesign}">
         <Setter Property="Background" Value="{StaticResource Red}" />
         <Setter Property="BorderColor" Value="{StaticResource Yellow}" />
         <Setter Property="TextColor" Value="{StaticResource White}" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Label.xaml
@@ -15,12 +15,10 @@
 
     <converters:BrushToBlackWhiteConverter x:Key="BrushToBlackWhiteConverter" />
 
-    <!-- DEFAULT LABEL STYLE -->
     <Style x:Key="Style.Core.Label.Default" TargetType="Label">
         <Setter Property="FontFamily" Value="{StaticResource MontserratSemiBold}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
-        <!--<Setter Property="FontSize" Value="{OnPlatform WinUI='Default', Default='Small'}"/>-->
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}"/>
     </Style>
 
@@ -52,52 +50,16 @@
         </Setter>
     </Style>
     
-    <!--  Common style for icon label  -->
-    <Style x:Key="Style.Core.Label.Icon" TargetType="Label">
+    <Style x:Key="Style.Core.Label.Icon.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="Margin" Value="16,8" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-        <!--<Setter Property="FontSize" Value="Medium" />-->
-        <!--<Setter Property="FontSize" Value="{OnPlatform WinUI=13, Default='Default'}" />-->
-        <Setter Property="FontSize" Value="{StaticResource DefaultIconSize}" />
-        <Setter Property="HorizontalTextAlignment" Value="Center" />
-        <Setter Property="VerticalTextAlignment" Value="Center" />
-        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
-    </Style>
-
-    <Style x:Key="Style.Core.Label.Icon.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-        <!--<Setter Property="FontSize" Value="Large"/>-->
-        <Setter Property="FontSize" Value="{StaticResource LargeTextSize}"/>
+        <Setter Property="FontSize" Value="{StaticResource DefaultIconSize}"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"/>
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
-    </Style>
-
-    <Style x:Key="Style.Core.Label.IconHeader" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
-        <Setter Property="Margin" Value="0" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
         <Setter Property="VerticalTextAlignment" Value="Center" />
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal">
-                        <VisualState.Setters>
-                            <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="PointerOver" />
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
     </Style>
 
-    <!--  Common style for icon label  -->
     <Style x:Key="Style.Core.Label.IconHeader.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
         <Setter Property="Margin" Value="0" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
@@ -124,11 +86,10 @@
     </Style>
 
     <Style x:Key="Style.Core.Label.IconSmall.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
-        <!--<Setter Property="FontSize" Value="Small" />-->
         <Setter Property="FontSize" Value="{StaticResource SmallTextSize}" />
     </Style>
 
-    <Style x:Key="Style.Core.Label.IconSettings.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon}">
+    <Style x:Key="Style.Core.Label.IconSettings.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
         <Setter Property="Margin" Value="4,0,0,0" />
         <Setter Property="Text" Value="{x:Static icons:MaterialIcons.VectorSquare}" />
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
@@ -151,12 +112,10 @@
 
     <Style x:Key="Style.Core.Label.Small" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}" />
-        <!--<Setter Property="FontSize" Value="Small" />-->
         <Setter Property="FontSize" Value="{StaticResource SmallTextSize}" />
     </Style>
 
     <Style x:Key="Style.Core.Label.VerySmall" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
-        <!--<Setter Property="FontSize" Value="Micro" />-->
         <Setter Property="FontSize" Value="{StaticResource MicroTextSize}" />
     </Style>
 
@@ -195,8 +154,6 @@
 
     <Style x:Key="Style.Core.Label.Settings" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="Margin" Value="16,0,0,0" />
-        <!--<Setter Property="FontSize" Value="Small" />-->
-        <!--<Setter Property="FontSize" Value="{OnPlatform WinUI='Default', Default='Small'}" />-->
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray800}, Dark={StaticResource Gray200}}"/>
         <Setter Property="LineHeight" Value="{OnPlatform Default=-1, Android=1.25}"/>
@@ -210,8 +167,6 @@
         <Setter Property="VerticalTextAlignment" Value="Center"/>
     </Style>
 
-    <!-- HEADLINES -->
-    <!-- Default headline label style -->
     <Style x:Key="Style.Core.Label.Headline" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Default}">
         <Setter Property="VerticalTextAlignment" Value="Center"/>
         <Setter Property="HorizontalTextAlignment" Value="Center"/>
@@ -228,27 +183,21 @@
 
     <Style x:Key="Style.Core.Label.TitleView" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.HeadlinePrimary}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}"/>
-        <!--<Setter Property="FontSize" Value="Medium" />-->
         <Setter Property="FontSize" Value="{StaticResource MediumTextSize}" />
     </Style>
 
-    <!-- PrimaryColor Dark Headline -->
     <Style x:Key="Style.Core.Label.HeadlinePrimaryDark" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Headline}">
         <Setter Property="TextColor" Value="{DynamicResource PrimaryDarkColor}"/>
     </Style>
 
-    <!--  Common style for swipe template content button control  -->
-    <Style x:Key="Style.Core.Label.IconSwipe" TargetType="Label">
-        <!-- Check if needed 
-        <Setter Property="Background" Value="Transparent" />-->
+    <Style x:Key="Style.Core.Label.IconSwipe.MaterialDesign" TargetType="Label">
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
         <Setter Property="VerticalTextAlignment" Value="Center" />
-        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
+        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
     </Style>
 
-    <!--  Common style for option labels  -->
     <Style
         x:Key="Style.Core.Label.Option"
         BasedOn="{StaticResource Style.Core.Label.Default}"
@@ -258,8 +207,6 @@
 
     <Style x:Key="Style.Core.Label.GroupingHeader" TargetType="Label">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray400}}" />
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=Medium, Default=Large}" />-->
-        <!--<Setter Property="FontSize" Value="{OnIdiom Desktop=18, Default=16}" /> -->
         <Setter Property="FontSize" Value="{StaticResource MediumTextSize}" />
         <Setter Property="VerticalTextAlignment" Value="Center" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
@@ -267,15 +214,8 @@
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.5, iOS=-1}" />
     </Style>
 
-    <!--  Common style for swipe template content button control  -->
-    <Style x:Key="Style.Core.Label.IconSwipe.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.IconSwipe}">
-        <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-    </Style>
-
     <Style x:Key="Style.Core.Span.Default" TargetType="Span">
         <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}" />
-        <!--<Setter Property="FontSize" Value="{StaticResource MediumTextSize}" />-->
-        <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}"/>-->
         <Setter Property="FontSize" Value="{Binding Source={RelativeSource AncestorType={x:Type Label}}, Path=FontSize}" />
         <Setter Property="TextColor" Value="{Binding Source={RelativeSource AncestorType={x:Type Label}}, Path=TextColor}" />
         <Setter Property="LineHeight" Value="{OnPlatform Default=1.25, iOS=-1}"/>
@@ -283,10 +223,6 @@
 
     <Style x:Key="Style.Core.Span.Icon.MaterialDesign" TargetType="Span" BasedOn="{StaticResource Style.Core.Span.Default}">
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignIcons}" />
-    </Style>
-
-    <Style x:Key="Style.Core.Span.Icon" TargetType="Span" BasedOn="{StaticResource Style.Core.Span.Icon.MaterialDesign}">
-        <Setter Property="FontFamily" Value="{StaticResource FontIcons}" />
     </Style>
 
     <Style x:Key="Style.Core.Span.IconTiny.MaterialDesign" TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedFonts.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedFonts.xaml
@@ -13,6 +13,5 @@
     <x:String x:Key="MontserratMedium">MontserratMedium</x:String>
     <x:String x:Key="MontserratRegular">MontserratRegular</x:String>
     <x:String x:Key="MontserratSemiBold">MontserratSemiBold</x:String>
-    <x:String x:Key="FontIcons">UIFontIcons</x:String>
 
 </ResourceDictionary>


### PR DESCRIPTION
This PR moves all core styles into the `Syncfusion` library which are using the `UIFontIcons` font provided by Syncfusion.

Fixed #449