### PR TITLE
Fixed `DropDownPanelBackground` for `ComboBox` and `SfAutocomplete`

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAutoComplete.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfAutoComplete.xaml
@@ -20,13 +20,11 @@
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
-        <!--
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        -->
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="DropDownStroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="SelectedDropDownItemBackground" Value="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}" />
         <!-- Seems to cause a crash -->
-        <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/><!---->
+        <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="Margin" Value="4,2"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -34,13 +32,17 @@
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray800}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -53,14 +55,10 @@
     <Style x:Key="Style.Syncfusion.MultiSelectAutoComplete.Default" TargetType="controls:MultiSelectAutoComplete">
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
-        <Setter Property="IsClearButtonVisible" Value="True" />
-        <!--
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        -->
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
-        <!-- Seems to cause a crash -->
-        <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/><!---->
+        <Setter Property="DropDownStroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="SelectedDropDownItemBackground" Value="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}" />
+        <Setter Property="FontFamily" Value="{StaticResource MontserratRegular}"/>
         <Setter Property="Margin" Value="4,2"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -68,13 +66,17 @@
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray800}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/Controls/SfComboBox.xaml
@@ -23,24 +23,26 @@
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
         <Setter Property="Margin" Value="4,2"/>
-        <!--
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        -->
         <Setter Property="Stroke" Value="{DynamicResource PrimaryColor}" />
+        <Setter Property="DropDownStroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="SelectedDropDownItemBackground" Value="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray800}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -57,10 +59,8 @@
         <Setter Property="ClearButtonIconColor" Value="{DynamicResource PrimaryColor}" />
         <Setter Property="IsClearButtonVisible" Value="True" />
         <Setter Property="Stroke" Value="{DynamicResource PrimaryColor}" />
-        <!--
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        -->
+        <Setter Property="DropDownStroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}" />
+        <Setter Property="SelectedDropDownItemBackground" Value="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}" />
         <Setter Property="Margin" Value="4,2"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -68,13 +68,17 @@
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray800}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray100}}" />
+                            <Setter Property="DropDownItemTextColor" Value="{Binding Source={RelativeSource Self}, Path=TextColor}" />
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
+                            <Setter Property="DropDownBackground" Value="{Binding Source={RelativeSource Self}, Path=Background}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -55,20 +55,20 @@
 	
 	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-	  <PackageReference Include="Syncfusion.Maui.Barcode" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Buttons" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Core" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Expander" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.ListView" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Picker" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.TabView" Version="24.2.9" />
-	  <PackageReference Include="Syncfusion.Maui.TreeView" Version="24.2.9" />
+	  <PackageReference Include="Syncfusion.Maui.Barcode" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Buttons" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Core" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Expander" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.ListView" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Picker" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.TabView" Version="25.1.35" />
+	  <PackageReference Include="Syncfusion.Maui.TreeView" Version="25.1.35" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.2" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR updates the syncfusion nugets to their latest version. Also now the `DropDownPanel`  can be styled.

![image](https://github.com/AndreasReitberger/SharedMauiXamlStyles/assets/2952443/1476d67f-0384-46a0-b50c-80c9c128f072)

Fixed #233