### PR TITLE
Fixed `MauiFont` embedding

### DIFF
--- a/common.props
+++ b/common.props
@@ -36,8 +36,8 @@
    </ItemGroup>
 -->
   <ItemGroup>
-	<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.14" />
-	<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.14" />
+	<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.20" />
+	<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.20" />
 	<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Hosting/AppHostBuilderExtensions.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Hosting/AppHostBuilderExtensions.cs
@@ -25,8 +25,8 @@ namespace AndreasReitberger.Shared.Syncfusion.Hosting
                         FontDescriptor fontDescriptor = fonts.FirstOrDefault(f => f.Filename == font.Key);
                         if (fontDescriptor == null)
                         {
-                            fonts.AddEmbeddedResourceFont(typeof(AppHostBuilderExtensions).Assembly, font.Key, font.Value);
-                            //fonts.AddFont(font.Key, font.Value);
+                            //fonts.AddEmbeddedResourceFont(typeof(AppHostBuilderExtensions).Assembly, font.Key, font.Value);
+                            fonts.AddFont(font.Key, font.Value);
                         }
                     }
                 });

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -43,33 +43,25 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <MauiFont Remove="Resources\Fonts\UIFontIcons.ttf" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <None Remove="Resources\Fonts\UIFontIcons.ttf" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <EmbeddedResource Include="Resources\Fonts\UIFontIcons.ttf" />
 	</ItemGroup>
 	
 	<ItemGroup>
 	  <ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-	  <PackageReference Include="Syncfusion.Maui.Barcode" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Buttons" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Core" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Expander" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.ListView" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Picker" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.TabView" Version="25.1.38" />
-	  <PackageReference Include="Syncfusion.Maui.TreeView" Version="25.1.38" />
+	  <PackageReference Include="Syncfusion.Maui.Barcode" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Buttons" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Core" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Expander" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Gauges" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Inputs" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.ListView" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Picker" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Scheduler" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.Sliders" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.TabView" Version="25.1.39" />
+	  <PackageReference Include="Syncfusion.Maui.TreeView" Version="25.1.39" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary/Hosting/AppHostBuilderExtensions.cs
+++ b/src/SharedMauiXamlStylesLibrary/Hosting/AppHostBuilderExtensions.cs
@@ -24,8 +24,8 @@ namespace AndreasReitberger.Shared.Hosting
                         FontDescriptor fontDescriptor = fonts.FirstOrDefault(f => f.Filename == font.Key);
                         if (fontDescriptor == null)
                         {
-                            fonts.AddEmbeddedResourceFont(typeof(AppHostBuilderExtensions).Assembly, font.Key, font.Value);
-                            //fonts.AddFont(font.Key, font.Value);
+                            //fonts.AddEmbeddedResourceFont(typeof(AppHostBuilderExtensions).Assembly, font.Key, font.Value);
+                            fonts.AddFont(font.Key, font.Value);
                         }
                     }
                 });

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -51,18 +51,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <EmbeddedResource Include="Resources\Fonts\FluentFontIcons.ttf" />
-	  <EmbeddedResource Include="Resources\Fonts\FontAwesome5Brands.otf" />
-	  <EmbeddedResource Include="Resources\Fonts\FontAwesome5Regular.otf" />
-	  <EmbeddedResource Include="Resources\Fonts\FontAwesome5Solid.otf" />
-	  <EmbeddedResource Include="Resources\Fonts\materialdesignicons-webfont.ttf" />
-	  <EmbeddedResource Include="Resources\Fonts\Montserrat-Bold.ttf" />
-	  <EmbeddedResource Include="Resources\Fonts\Montserrat-Medium.ttf" />
-	  <EmbeddedResource Include="Resources\Fonts\Montserrat-Regular.ttf" />
-	  <EmbeddedResource Include="Resources\Fonts\Montserrat-SemiBold.ttf" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.6" />
 	</ItemGroup>
 


### PR DESCRIPTION
This PR fixes the way how the fonts are embedded in the core library. This should fix the issue that fonts are not loaded if the application is published as non-msix package.

Fixed #493