### PR TITLE
Added workaround to add `MauiFonts` to nuget packages

### DIFF
--- a/SharedMauiXamlStylesLibrary.Syncfusion.targets
+++ b/SharedMauiXamlStylesLibrary.Syncfusion.targets
@@ -1,0 +1,6 @@
+<Project>
+    <!-- https://github.com/dotnet/maui/issues/10019#issuecomment-1248032520 -->
+  <ItemGroup>
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\UIFontIcons.ttf" />
+  </ItemGroup>
+</Project>

--- a/SharedMauiXamlStylesLibrary.targets
+++ b/SharedMauiXamlStylesLibrary.targets
@@ -1,0 +1,13 @@
+<Project>
+    <!-- https://github.com/dotnet/maui/issues/10019#issuecomment-1248032520 -->
+  <ItemGroup>
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\FluentFontIcons.ttf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\FontAwesome5Brands.otf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\FontAwesome5Solid.otf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\materialdesignicons-webfont.ttf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\Montserrat-Bold.ttf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\Montserrat-Medium.ttf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\Montserrat-Regular.ttf" />
+    <MauiFont Include="$(MSBuildThisFileDirectory)\Resources\Fonts\Montserrat-SemiBold.ttf" />
+  </ItemGroup>
+</Project>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -39,11 +39,16 @@
 
 	<ItemGroup>
 		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
+		<MauiFont Include="Resources\Fonts\*" Pack="True" PackagePath="buildTransitive\Fonts\"/>
 	</ItemGroup>
 
 	<ItemGroup>
 	  <None Remove="Resources\Fonts\UIFontIcons.ttf" />
+	</ItemGroup>
+
+	<!-- Workaround: https://github.com/dotnet/maui/issues/10019#issuecomment-1248032520 -->
+	<ItemGroup>
+		<None Include="..\..\SharedMauiXamlStylesLibrary.Syncfusion.targets" Pack="True" PackagePath="buildTransitive\" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary.sln
+++ b/src/SharedMauiXamlStylesLibrary.sln
@@ -10,6 +10,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{92DEA009-5D62-4FDC-B16E-11E927D1F279}"
 	ProjectSection(SolutionItems) = preProject
 		..\common.props = ..\common.props
+		..\SharedMauiXamlStylesLibrary.Syncfusion.targets = ..\SharedMauiXamlStylesLibrary.Syncfusion.targets
+		..\SharedMauiXamlStylesLibrary.targets = ..\SharedMauiXamlStylesLibrary.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedMauiXamlStylesLibrary.SampleApp", "SharedMauiXamlStylesLibrary.SampleApp\SharedMauiXamlStylesLibrary.SampleApp.csproj", "{70168733-B647-481A-92C3-49C4F28D1DB4}"

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -37,9 +37,13 @@
 
 	<ItemGroup>
 		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
+		<MauiFont Include="Resources\Fonts\*" Pack="True" PackagePath="buildTransitive\Fonts\" />
 	</ItemGroup>
-
+	<!-- Workaround: https://github.com/dotnet/maui/issues/10019#issuecomment-1248032520 -->
+	<ItemGroup>
+		<None Include="..\..\SharedMauiXamlStylesLibrary.targets" Pack="True" PackagePath="buildTransitive\" />
+	</ItemGroup>
+	
 	<ItemGroup>
 	  <None Include="..\..\licenses\FontAwesome.txt" Link="Licenses\LicenseFiles\FontAwesome.txt" />
 	  <None Include="..\..\licenses\MaterialDesignIcons.txt" Link="Licenses\LicenseFiles\MaterialDesignIcons.txt" />


### PR DESCRIPTION
This PR adds the `MauiFonts` to the nuget package.
Workaround: https://github.com/dotnet/maui/issues/10019#issuecomment-1248032520

So it is not necessary anymore to also add the fonts to the maui parent project.

Fixed #495