### PR TITLE
Updated `SortFilterHeaderConventView` to use `Buttons`

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.2.11</Version>
+        <Version>1.2.12</Version>
         <PackageIcon>ar_128.png</PackageIcon>
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/SharedMauiXamlStyles</PackageProjectUrl>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SortFilterHeaderConventView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SortFilterHeaderConventView.xaml
@@ -16,6 +16,30 @@
                     Grid.Column="1"
                     CompressedLayout.IsHeadless="True"
                     >
+                    <Button
+                        MinimumHeightRequest="{OnIdiom Phone=32, Default=48}"
+                        Margin="0"
+                        Padding="8,0"
+                        CornerRadius="0"
+                        Text="{TemplateBinding SortButtonText}"
+                        Command="{TemplateBinding SortButtonCommand}"
+                        CommandParameter="{TemplateBinding CommandParameter}"
+                        Grid.Column="1"
+                        Background="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                        TextColor="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}"
+                        BorderWidth="0"
+                        Style="{StaticResource Style.Core.Button.Default}"
+                        >
+                        <Button.ImageSource>
+                            <FontImageSource
+                                FontFamily="{TemplateBinding ButtonIconFontFamily}"
+                                Glyph="{TemplateBinding SortButtonIconText}"
+                                Color="{Binding Source={RelativeSource AncestorType={x:Type Button}, AncestorLevel=1}, Path=TextColor}"
+                                Size="Small"
+                                />
+                        </Button.ImageSource>
+                    </Button>
+                    <!-- Workaround (not needed any more)
                     <Label
                         Style="{StaticResource Style.Core.Label.Header}"
                         VerticalTextAlignment="Center"
@@ -25,7 +49,7 @@
                                 <Span 
                                     Text="{TemplateBinding SortButtonIconText}"
                                     FontFamily="{TemplateBinding ButtonIconFontFamily}"
-                                    Style="{StaticResource Style.Core.Span.Icon}" 
+                                    Style="{StaticResource Style.Core.Span.Icon.MaterialDesign}" 
                                     />
                                 <Span Text="  " />
                                 <Span Text="{TemplateBinding SortButtonText}" />
@@ -39,7 +63,31 @@
                                 />
                         </Label.GestureRecognizers>
                     </Label>
-
+                    -->
+                    <Button
+                        IsVisible="{TemplateBinding ShowFilterButton}"
+                        MinimumHeightRequest="{OnIdiom Phone=32, Default=48}"
+                        Margin="0"
+                        Padding="8,0"
+                        CornerRadius="0"
+                        Text="{TemplateBinding FilterButtonText}"
+                        Command="{TemplateBinding FilterButtonCommand}"
+                        CommandParameter="{TemplateBinding CommandParameter}"
+                        Background="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                        TextColor="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}"
+                        BorderWidth="0"
+                        Style="{StaticResource Style.Core.Button.Default}"
+                        >
+                        <Button.ImageSource>
+                            <FontImageSource
+                                FontFamily="{TemplateBinding ButtonIconFontFamily}"
+                                Glyph="{TemplateBinding FilterButtonIconText}"
+                                Color="{Binding Source={RelativeSource AncestorType={x:Type Button}, AncestorLevel=1}, Path=TextColor}"
+                                Size="Small"
+                                />
+                        </Button.ImageSource>
+                    </Button>
+                    <!-- Workaround (not needed any more)
                     <Label
                         Style="{StaticResource Style.Core.Label.Header}"
                         VerticalTextAlignment="Center"
@@ -50,7 +98,7 @@
                                 <Span 
                                     Text="{TemplateBinding FilterButtonIconText}"
                                     FontFamily="{TemplateBinding ButtonIconFontFamily}"
-                                    Style="{StaticResource Style.Core.Span.Icon}" 
+                                    Style="{StaticResource Style.Core.Span.Icon.MaterialDesign}" 
                                     />
                                 <Span Text="  " />
                                 <Span Text="{TemplateBinding FilterButtonText}" />
@@ -64,6 +112,7 @@
                                 />
                         </Label.GestureRecognizers>
                     </Label>
+                    -->
                     <!-- Clear Filter -->
                     <Button
                         Margin="2,4"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SortFilterHeaderConventView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SortFilterHeaderConventView.xaml.cs
@@ -3,7 +3,7 @@ using AndreasReitberger.Shared.Syncfusion.FontIcons;
 
 namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
 
-
+[Obsolete("Use the view from `AndreasReitberger.Shared.ContentViews` instead")]
 public partial class SortFilterHeaderConventView : ContentView
 {
     #region Bindings
@@ -12,7 +12,7 @@ public partial class SortFilterHeaderConventView : ContentView
     public static readonly BindableProperty ShowFilterButtonProperty = BindableProperty.Create(nameof(ShowFilterButton), typeof(bool), typeof(SortFilterHeaderConventView), true);
 
     public static readonly BindableProperty ButtonIconFontFamilyProperty = BindableProperty.Create(nameof(ButtonIconFontFamily), typeof(string), typeof(SortFilterHeaderConventView), "UIFontIcons");
-    public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(ButtonIconFontFamily), typeof(object), typeof(SortFilterHeaderConventView), null);
+    public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SortFilterHeaderConventView), null);
 
     public static readonly BindableProperty SortButtonTextProperty = BindableProperty.Create(nameof(SortButtonText), typeof(string), typeof(SortFilterHeaderConventView), string.Empty);
     public static readonly BindableProperty FilterButtonTextProperty = BindableProperty.Create(nameof(FilterButtonText), typeof(string), typeof(SortFilterHeaderConventView), string.Empty);

--- a/src/SharedMauiXamlStylesLibrary/ContentViews/SortFilterHeaderConventView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/ContentViews/SortFilterHeaderConventView.xaml
@@ -15,7 +15,28 @@
                     Margin="4,0"
                     Grid.Column="1"
                     CompressedLayout.IsHeadless="True"
+                    HeightRequest="{TemplateBinding ContainerHeight}"
                     >
+                    <Button
+                        MinimumWidthRequest="{OnIdiom Phone=92, Default=144}"
+                        Margin="0"
+                        CornerRadius="0"
+                        Text="{TemplateBinding SortButtonText}"
+                        Command="{TemplateBinding SortButtonCommand}"
+                        CommandParameter="{TemplateBinding CommandParameter}"
+                        BorderWidth="0"
+                        Style="{StaticResource Style.Core.Button.Default}"
+                        >
+                        <Button.ImageSource>
+                            <FontImageSource
+                                FontFamily="{TemplateBinding ButtonIconFontFamily}"
+                                Glyph="{TemplateBinding SortButtonIconText}"
+                                Color="{Binding Source={RelativeSource AncestorType={x:Type Button}, AncestorLevel=1}, Path=TextColor}"
+                                Size="Small"
+                                />
+                        </Button.ImageSource>
+                    </Button>
+                    <!-- Workaround (not needed any more)
                     <Label
                         Style="{StaticResource Style.Core.Label.Header}"
                         VerticalTextAlignment="Center"
@@ -39,7 +60,28 @@
                                 />
                         </Label.GestureRecognizers>
                     </Label>
-
+                    -->
+                    <Button
+                        IsVisible="{TemplateBinding ShowFilterButton}"
+                        MinimumWidthRequest="{OnIdiom Phone=92, Default=144}"
+                        Margin="0"
+                        CornerRadius="0"
+                        Text="{TemplateBinding FilterButtonText}"
+                        Command="{TemplateBinding FilterButtonCommand}"
+                        CommandParameter="{TemplateBinding CommandParameter}"
+                        BorderWidth="0"
+                        Style="{StaticResource Style.Core.Button.Default}"
+                        >
+                        <Button.ImageSource>
+                            <FontImageSource
+                                FontFamily="{TemplateBinding ButtonIconFontFamily}"
+                                Glyph="{TemplateBinding FilterButtonIconText}"
+                                Color="{Binding Source={RelativeSource AncestorType={x:Type Button}, AncestorLevel=1}, Path=TextColor}"
+                                Size="Small"
+                                />
+                        </Button.ImageSource>
+                    </Button>
+                    <!-- Workaround (not needed any more)
                     <Label
                         Style="{StaticResource Style.Core.Label.Header}"
                         VerticalTextAlignment="Center"
@@ -64,6 +106,7 @@
                                 />
                         </Label.GestureRecognizers>
                     </Label>
+                    -->                  
                     <!-- Clear Filter -->
                     <Button
                         Margin="2,4"

--- a/src/SharedMauiXamlStylesLibrary/ContentViews/SortFilterHeaderConventView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary/ContentViews/SortFilterHeaderConventView.xaml.cs
@@ -8,10 +8,11 @@ public partial class SortFilterHeaderConventView : ContentView
     #region Bindings
 
     public static readonly BindableProperty IsFilteredProperty = BindableProperty.Create(nameof(IsFiltered), typeof(bool), typeof(SortFilterHeaderConventView), false);
+    public static readonly BindableProperty ContainerHeightProperty = BindableProperty.Create(nameof(ContainerHeight), typeof(int), typeof(SortFilterHeaderConventView), 45);
     public static readonly BindableProperty ShowFilterButtonProperty = BindableProperty.Create(nameof(ShowFilterButton), typeof(bool), typeof(SortFilterHeaderConventView), true);
 
     public static readonly BindableProperty ButtonIconFontFamilyProperty = BindableProperty.Create(nameof(ButtonIconFontFamily), typeof(string), typeof(SortFilterHeaderConventView), "MaterialDesignIcons");
-    public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(ButtonIconFontFamily), typeof(object), typeof(SortFilterHeaderConventView), null);
+    public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SortFilterHeaderConventView), null);
 
     public static readonly BindableProperty SortButtonTextProperty = BindableProperty.Create(nameof(SortButtonText), typeof(string), typeof(SortFilterHeaderConventView), string.Empty);
     public static readonly BindableProperty FilterButtonTextProperty = BindableProperty.Create(nameof(FilterButtonText), typeof(string), typeof(SortFilterHeaderConventView), string.Empty);
@@ -69,6 +70,12 @@ public partial class SortFilterHeaderConventView : ContentView
     {
         get => (bool)GetValue(IsFilteredProperty);
         set => SetValue(IsFilteredProperty, value);
+    }
+
+    public int ContainerHeight
+    {
+        get => (int)GetValue(ContainerHeightProperty);
+        set => SetValue(ContainerHeightProperty, value);
     }
 
     public bool ShowFilterButton

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/Button.xaml
@@ -28,16 +28,10 @@
         <Setter Property="FontSize" Value="{StaticResource DefaultTextSize}" />
         <Setter Property="MinimumHeightRequest" Value="50" />
         <Setter Property="BorderWidth" Value="0" />
+        <Setter Property="ContentLayout" Value="Left, 10" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="PointerOver" >
-                        <VisualState.Setters>
-                            <Setter Property="Background" Value="{DynamicResource PrimaryDarkenColor}"/>
-                            <!--<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray50}}"/>-->
-                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
-                        </VisualState.Setters>
-                    </VisualState>
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
                             <Setter Property="Background" Value="{DynamicResource PrimaryColor}"/>
@@ -48,6 +42,13 @@
                         <VisualState.Setters>
                             <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
                             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkGray}, Dark={StaticResource LightGray}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" >
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{DynamicResource PrimaryDarkenColor}"/>
+                            <!--<Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray50}}"/>-->
+                            <Setter Property="TextColor" Value="{Binding Source={RelativeSource Self}, Path=Background, Converter={StaticResource BrushToBlackWhiteConverter}}" />
                         </VisualState.Setters>
                     </VisualState>
                     <!--


### PR DESCRIPTION
This PR replaces the `Label` control with a `Button`. This was a workaround of an existing MAUI bug, which is no resolved. This reverts the changes.

Fixed #528