### PR TITLE
Removed `ViewCell` from `ItemTemplates`

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/SfListViewPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/SfListViewPage.xaml
@@ -21,52 +21,52 @@
     >
     <ContentPage.Resources>
         <converters:ColorToBlackWhiteConverter x:Key="ColorToBlackWhiteConverter" />
+        <DataTemplate x:Key="DataTemplate.Syncfusion.DemoItem" x:DataType="viewModels:DemoItem">
+            <Label
+                Text="{Binding Name}"
+                Style="{StaticResource Style.Core.Label.Medium}"
+                />
+        </DataTemplate>
         <DataTemplate x:Key="DataTemplate.Syncfusion.Header.Custom">
-            <ViewCell>
-                <!-- 
-                    IsFiltered="{Binding Source={RelativeSource AncestorType={x:Type controls:SearchableListView}}, Path=IsFiltered}"
-                -->
-                <views:SortFilterHeaderConventView
-                    Background="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}"
-                    SortButtonCommand="{Binding SortCommand}"
-                    SortButtonIconText="{x:Static icons:MaterialIcons.Sort}"
-                    SortButtonText="Sort"
-                    FilterButtonCommand="{Binding FilterCommand}"
-                    FilterButtonIconText="{x:Static icons:MaterialIcons.Filter}"
-                    FilterButtonText="Filter"
-                    ClearButtonCommand="{Binding ClearCommand}"
-                    ClearButtonIconText="{x:Static icons:MaterialIcons.Close}"
-                    IsFiltered="True"
-                    />
-            </ViewCell>
+            <!-- 
+                IsFiltered="{Binding Source={RelativeSource AncestorType={x:Type controls:SearchableListView}}, Path=IsFiltered}"
+            -->
+            <views:SortFilterHeaderConventView
+                Background="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}"
+                SortButtonCommand="{Binding SortCommand}"
+                SortButtonIconText="{x:Static icons:MaterialIcons.Sort}"
+                SortButtonText="Sort"
+                FilterButtonCommand="{Binding FilterCommand}"
+                FilterButtonIconText="{x:Static icons:MaterialIcons.Filter}"
+                FilterButtonText="Filter"
+                ClearButtonCommand="{Binding ClearCommand}"
+                ClearButtonIconText="{x:Static icons:MaterialIcons.Close}"
+                IsFiltered="True"
+                />
         </DataTemplate>
         <DataTemplate x:Key="DataTemplate.Syncfusion.Header.SwitchYear">
-            <ViewCell>
-                <views:SwitchHeaderConventView
-                     Background="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}"
-                     BackButtonCommand="{Binding ValueBackCommand}"
-                     BackButtonIconText="{x:Static icons:MaterialIcons.ArrowLeft}"
-                     BackButtonText=""
-                     NextButtonCommand="{Binding ValueNextCommand}"
-                     NextButtonIconText="{x:Static icons:MaterialIcons.ArrowRight}"
-                     NextButtonText=""
-                     TitleLabelText="Year"
-                     />
-            </ViewCell>
+            <views:SwitchHeaderConventView
+                Background="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}"
+                BackButtonCommand="{Binding ValueBackCommand}"
+                BackButtonIconText="{x:Static icons:MaterialIcons.ArrowLeft}"
+                BackButtonText=""
+                NextButtonCommand="{Binding ValueNextCommand}"
+                NextButtonIconText="{x:Static icons:MaterialIcons.ArrowRight}"
+                NextButtonText=""
+                TitleLabelText="Year"
+                />
         </DataTemplate>
         <DataTemplate x:Key="DataTemplate.Syncfusion.Header.SwitchPage">
-            <ViewCell>
-                <views:SwitchHeaderConventView
-                     Background="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}"
-                     BackButtonCommand="{Binding ValueBackCommand}"
-                     BackButtonIconText="{x:Static icons:MaterialIcons.ArrowLeft}"
-                     BackButtonText=""
-                     NextButtonCommand="{Binding ValueNextCommand}"
-                     NextButtonIconText="{x:Static icons:MaterialIcons.ArrowRight}"
-                     NextButtonText=""
-                     TitleLabelText="Page"
-                     />
-            </ViewCell>
+            <views:SwitchHeaderConventView
+                    Background="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}"
+                    BackButtonCommand="{Binding ValueBackCommand}"
+                    BackButtonIconText="{x:Static icons:MaterialIcons.ArrowLeft}"
+                    BackButtonText=""
+                    NextButtonCommand="{Binding ValueNextCommand}"
+                    NextButtonIconText="{x:Static icons:MaterialIcons.ArrowRight}"
+                    NextButtonText=""
+                    TitleLabelText="Page"
+                    />
         </DataTemplate>
     </ContentPage.Resources>
 
@@ -80,6 +80,7 @@
             <listView:SfListView
                 Style="{StaticResource Style.Syncfusion.SfListView.Default}"
                 HeaderTemplate="{StaticResource DataTemplate.Syncfusion.Header.Custom}"
+                ItemTemplate="{StaticResource DataTemplate.Syncfusion.DemoItem}"
                 ItemsSource="{Binding Items}"
                 SelectedItem="{Binding Item}"
                 >
@@ -91,6 +92,7 @@
             >
             <listView:SfListView
                 Style="{StaticResource Style.Syncfusion.SfListView.Default}"
+                ItemTemplate="{StaticResource DataTemplate.Syncfusion.DemoItem}"
                 HeaderTemplate="{StaticResource DataTemplate.Syncfusion.Header.SwitchYear}"
                 ItemsSource="{Binding Items}"
                 SelectedItem="{Binding Item}"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/GeneralItemTemplates.xaml
@@ -9,8 +9,7 @@
     >
 
     <DataTemplate x:Key="DataTemplate.Syncfusion.Contact.Default">
-        <ViewCell>
-            <Grid 
+        <Grid 
                 Padding="8,6"
                 ColumnSpacing="4"
                 RowSpacing="4"
@@ -44,6 +43,5 @@
                     </Label.FormattedText>
                 </Label>
             </Grid>
-        </ViewCell>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -19,8 +19,7 @@
     <converters:UriToStringConverter x:Key="UriToStringConverter" />
 
     <DataTemplate x:Key="DataTemplate.Syncfusion.Header.Group">
-        <ViewCell>
-            <StackLayout 
+        <StackLayout 
                 Style="{StaticResource Style.Core.StackLayout.Header}" 
                 Orientation="Horizontal"
                 >
@@ -47,6 +46,5 @@
                     Margin="0,4"
                     />
             </StackLayout>
-        </ViewCell>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -18,8 +18,7 @@
     <converters:UriToStringConverter x:Key="UriToStringConverter" />
 
     <DataTemplate x:Key="DataTemplate.Syncfusion.ProVersionFeature.Default" x:DataType="documentation:ProVersionFeature">
-        <ViewCell>
-            <Grid 
+        <Grid 
                 Padding="8,6"
                 ColumnSpacing="4"
                 RowSpacing="4"
@@ -46,6 +45,5 @@
                     HorizontalTextAlignment="Start"
                     />
             </Grid>
-        </ViewCell>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewSwipeTemplates.xaml
@@ -493,64 +493,62 @@
     </DataTemplate>
 
     <DataTemplate x:Key="DataTemplate.Syncfusion.Swipe.DuplicateEditDelete">
-        <ViewCell>
-            <Grid
-                ColumnDefinitions="*,*,*"
+        <Grid
+            ColumnDefinitions="*,*,*"
+            >
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Viewed}"
+                TextColor="{StaticResource White}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                Background="{StaticResource Blue}"
                 >
-                <Label
-                    Style="{StaticResource Style.Core.Label.Icon}"
-                    Text="{x:Static iconsSyncfusion:SyncfusionIcons.Viewed}"
-                    TextColor="{StaticResource White}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center"
-                    Margin="0"
-                    Background="{StaticResource Blue}"
-                    >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
-                            NumberOfTapsRequired="1"
-                            Command="{Binding BindingContext.DuplicateItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
-                            CommandParameter="{Binding .}"
-                            />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
-                    Grid.Column="1"
-                    Style="{StaticResource Style.Core.Label.Icon}"
-                    Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
-                    TextColor="{StaticResource White}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center"
-                    Margin="0"
-                    Background="{StaticResource Green}"
-                    >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
-                            NumberOfTapsRequired="1"
-                            Command="{Binding BindingContext.EditItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
-                            CommandParameter="{Binding .}"
-                            />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label
-                    Grid.Column="2"
-                    Style="{StaticResource Style.Core.Label.Icon}"
-                    Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
-                    TextColor="{StaticResource White}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center"
-                    Margin="0"
-                    Background="{StaticResource Red}"
-                    >
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer
-                            NumberOfTapsRequired="1"
-                            Command="{Binding BindingContext.DeleteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
-                            CommandParameter="{Binding .}"
-                            />
-                    </Label.GestureRecognizers>
-                </Label>
-            </Grid>
-        </ViewCell>
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding BindingContext.DuplicateItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                        CommandParameter="{Binding .}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
+                Grid.Column="1"
+                Style="{StaticResource Style.Core.Label.Icon}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
+                TextColor="{StaticResource White}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                Background="{StaticResource Green}"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding BindingContext.EditItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                        CommandParameter="{Binding .}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            <Label
+                Grid.Column="2"
+                Style="{StaticResource Style.Core.Label.Icon}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
+                TextColor="{StaticResource White}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                Background="{StaticResource Red}"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding BindingContext.DeleteItemCommand, Source={x:RelativeSource AncestorType={x:Type listView:SfListView}, AncestorLevel=1}}"
+                        CommandParameter="{Binding .}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+        </Grid>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -15,34 +15,32 @@
     <converters:UriToStringConverter x:Key="UriToStringConverter" />
 
     <DataTemplate x:Key="DataTemplate.Core.Header.Group">
-        <ViewCell>
-            <StackLayout 
-                Style="{StaticResource Style.Core.StackLayout.Header}" 
-                Orientation="Horizontal"
-                >
-                <!-- Icon -->
-                <Label Margin="10,4">
-                    <Label.Style>
-                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
-                            <Setter Property="Text" Value="{x:Static icons:MaterialIcons.ArrowDown}"/>
-                            <Style.Triggers>
-                                <DataTrigger TargetType="Label" Binding="{Binding IsExpand}" Value="True">
-                                    <Setter Property="Text" Value="{x:Static icons:MaterialIcons.ArrowUp}"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Label.Style>
-                </Label>
+        <StackLayout 
+            Style="{StaticResource Style.Core.StackLayout.Header}" 
+            Orientation="Horizontal"
+            >
+            <!-- Icon -->
+            <Label Margin="10,4">
+                <Label.Style>
+                    <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
+                        <Setter Property="Text" Value="{x:Static icons:MaterialIcons.ArrowDown}"/>
+                        <Style.Triggers>
+                            <DataTrigger TargetType="Label" Binding="{Binding IsExpand}" Value="True">
+                                <Setter Property="Text" Value="{x:Static icons:MaterialIcons.ArrowUp}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Label.Style>
+            </Label>
 
-                <Label 
-                    Text="{Binding Key}" 
-                    Style="{StaticResource Style.Core.Label.GroupingHeader}"
-                    FontAttributes="Bold"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Start"
-                    Margin="0,4"
-                    />
-            </StackLayout>
-        </ViewCell>
+            <Label 
+                Text="{Binding Key}" 
+                Style="{StaticResource Style.Core.Label.GroupingHeader}"
+                FontAttributes="Bold"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Start"
+                Margin="0,4"
+                />
+        </StackLayout>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewItemTemplates.xaml
@@ -15,266 +15,247 @@
     <converters:UriToStringConverter x:Key="UriToStringConverter" />
 
     <DataTemplate x:Key="DataTemplate.Core.ProVersionFeature.Default" x:DataType="documentation:ProVersionFeature">
-        <ViewCell>
-            <Grid 
-                Padding="8,6"
-                ColumnSpacing="4"
-                RowSpacing="4"
-                ColumnDefinitions="Auto,*"
+        <Grid 
+            Padding="8,6"
+            ColumnSpacing="4"
+            RowSpacing="4"
+            ColumnDefinitions="Auto,*"
+            >
+            <!-- Check icon -->
+            <Border
+                Style="{StaticResource Style.Core.Border.Profile}"
+                Background="{StaticResource LightGreen}"
+                Margin="0"
                 >
-                <!-- Check icon -->
-                <Border
-                    Style="{StaticResource Style.Core.Border.Profile}"
-                    Background="{StaticResource LightGreen}"
-                    Margin="0"
-                    >
-                    <Label 
-                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
-                        Text="{x:Static icons:MaterialIcons.Check}"
-                        TextColor="{StaticResource White}"
-                        />
-                </Border>
-
                 <Label 
-                    Grid.Column="1"
-                    Text="{Binding Feature}"
-                    Style="{StaticResource Style.Core.Label.Default}"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Start"
+                    Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
+                    Text="{x:Static icons:MaterialIcons.Check}"
+                    TextColor="{StaticResource White}"
                     />
-            </Grid>
-        </ViewCell>
+            </Border>
+
+            <Label 
+                Grid.Column="1"
+                Text="{Binding Feature}"
+                Style="{StaticResource Style.Core.Label.Default}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Start"
+                />
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="DataTemplate.Core.AppEvent.Default" x:DataType="eventLogger:AppEvent">
-        <ViewCell>
-            <Grid 
-                x:Name="Grid"
-                Padding="16,12"
-                ColumnSpacing="16"
-                RowSpacing="2"
-                RowDefinitions="Auto"
-                ColumnDefinitions="48,*"
+        <Grid 
+            x:Name="Grid"
+            Padding="16,12"
+            ColumnSpacing="16"
+            RowSpacing="2"
+            RowDefinitions="Auto"
+            ColumnDefinitions="48,*"
+            >
+            <!-- Icon -->
+            <Label
+                Margin="3.5,0,0,0" 
+                HorizontalTextAlignment="Center"
+                VerticalTextAlignment="Center"
                 >
-                <!-- Icon -->
-                <Label
-                    Margin="3.5,0,0,0" 
-                    HorizontalTextAlignment="Center"
+                <Label.Style>
+                    <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
+                        <Setter Property="Text" Value="{x:Static icons:MaterialIcons.AlertCircleOutline}"/>
+                        <Style.Triggers>
+                            <!-- Info -->
+                            <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Info">
+                                <Setter Property="Text" Value="{x:Static icons:MaterialIcons.InformationOutline}"/>
+                                <Setter Property="TextColor" Value="{StaticResource Blue}"/>
+                            </DataTrigger>
+                            <!-- Alert -->
+                            <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Warning">
+                                <Setter Property="Text" Value="{x:Static icons:MaterialIcons.AlertCircleOutline}"/>
+                                <Setter Property="TextColor" Value="{StaticResource Yellow}"/>
+                            </DataTrigger>
+                            <!-- Error -->
+                            <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Critical">
+                                <Setter Property="Text" Value="{x:Static icons:MaterialIcons.CloseCircleOutline}"/>
+                                <Setter Property="TextColor" Value="{StaticResource Red}"/>
+                            </DataTrigger>
+                            <!-- Performance -->
+                            <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Performance">
+                                <Setter Property="Text" Value="{x:Static icons:MaterialIcons.Speedometer}"/>
+                                <Setter Property="TextColor" Value="{StaticResource LightGreen}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Label.Style>
+            </Label>
+            <!-- Quick Infos -->
+            <StackLayout 
+                Grid.Column="1" 
+                Spacing="1"
+                CompressedLayout.IsHeadless="true"
+                >
+                <Label 
+                    LineBreakMode="WordWrap" 
+                    Style="{StaticResource Style.Core.Label.Small}" 
+                    Text="{Binding Message}"
+                    FontAttributes="Bold"
+                    VerticalTextAlignment="Center"
+                    />
+                <Label 
+                    LineBreakMode="WordWrap" 
+                    Text="{Binding Args}"
                     VerticalTextAlignment="Center"
                     >
                     <Label.Style>
-                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Icon.MaterialDesign}">
-                            <Setter Property="Text" Value="{x:Static icons:MaterialIcons.AlertCircleOutline}"/>
+                        <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
+                            <Setter Property="IsVisible" Value="True"/>
                             <Style.Triggers>
-                                <!-- Info -->
-                                <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Info">
-                                    <Setter Property="Text" Value="{x:Static icons:MaterialIcons.InformationOutline}"/>
-                                    <Setter Property="TextColor" Value="{StaticResource Blue}"/>
-                                </DataTrigger>
-                                <!-- Alert -->
-                                <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Warning">
-                                    <Setter Property="Text" Value="{x:Static icons:MaterialIcons.AlertCircleOutline}"/>
-                                    <Setter Property="TextColor" Value="{StaticResource Yellow}"/>
-                                </DataTrigger>
-                                <!-- Error -->
-                                <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Critical">
-                                    <Setter Property="Text" Value="{x:Static icons:MaterialIcons.CloseCircleOutline}"/>
-                                    <Setter Property="TextColor" Value="{StaticResource Red}"/>
-                                </DataTrigger>
-                                <!-- Performance -->
-                                <DataTrigger TargetType="Label" Binding="{Binding Level}" Value="Performance">
-                                    <Setter Property="Text" Value="{x:Static icons:MaterialIcons.Speedometer}"/>
-                                    <Setter Property="TextColor" Value="{StaticResource LightGreen}"/>
+                                <!-- Has no args -->
+                                <DataTrigger TargetType="Label" Binding="{Binding Args}" Value="{x:Null}">
+                                    <Setter Property="IsVisible" Value="False"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </Label.Style>
                 </Label>
-                <!-- Quick Infos -->
-                <StackLayout 
-                    Grid.Column="1" 
-                    Spacing="1"
-                    CompressedLayout.IsHeadless="true"
-                    >
-                    <Label 
-                        LineBreakMode="WordWrap" 
-                        Style="{StaticResource Style.Core.Label.Small}" 
-                        Text="{Binding Message}"
-                        FontAttributes="Bold"
-                        VerticalTextAlignment="Center"
-                        />
-                    <Label 
-                        LineBreakMode="WordWrap" 
-                        Text="{Binding Args}"
-                        VerticalTextAlignment="Center"
-                        >
-                        <Label.Style>
-                            <Style TargetType="Label" BasedOn="{StaticResource Style.Core.Label.Small}">
-                                <Setter Property="IsVisible" Value="True"/>
-                                <Style.Triggers>
-                                    <!-- Has no args -->
-                                    <DataTrigger TargetType="Label" Binding="{Binding Args}" Value="{x:Null}">
-                                        <Setter Property="IsVisible" Value="False"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Label.Style>
-                    </Label>
-                </StackLayout>
-            </Grid>
-        </ViewCell>
+            </StackLayout>
+        </Grid>
     </DataTemplate>
 
     <!-- Localization -->
     <DataTemplate x:Key="DataTemplate.Core.LocalizationInfo.Default" x:DataType="language:LocalizationInfo">
-        <ViewCell>
-            <Grid 
-                Padding="2" 
-                Margin="1" 
-                ColumnDefinitions="48,*"
+        <Grid 
+            Padding="2" 
+            Margin="1" 
+            ColumnDefinitions="48,*"
+            RowDefinitions="{OnIdiom Tablet=80, Default=60}"
+            >
+            <!-- Flag -->
+            <Image 
+                HeightRequest="24"                                          
+                Source="{Binding FlagUri, Converter={StaticResource UriToStringConverter}}"
+                />
+            <!-- Infos -->
+            <StackLayout
+                Grid.Column="1"
+                Spacing="1" 
+                Padding="2,5,-10,0"
+                CompressedLayout.IsHeadless="true"
                 >
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="{OnIdiom Tablet=80, Default=60}" />
-                </Grid.RowDefinitions>
-                <!-- Flag -->
-                <Image 
-                    HeightRequest="24"                                          
-                    Source="{Binding FlagUri, Converter={StaticResource UriToStringConverter}}"
+                <!-- Language name -->
+                <Label 
+                    LineBreakMode="NoWrap" 
+                    Style="{StaticResource Style.Core.Label.Primary}" 
+                    Text="{Binding Name}"
                     />
-
-                <!-- Infos -->
-                <StackLayout
-                    Grid.Column="1"
-                    Spacing="1" 
-                    Padding="2,5,-10,0"
-                    CompressedLayout.IsHeadless="true"
-                    >
-                    <!-- Language name -->
-                    <Label 
-                        LineBreakMode="NoWrap" 
-                        Style="{StaticResource Style.Core.Label.Primary}" 
-                        Text="{Binding Name}"
-                        />
-                    <!-- Translator -->
-                    <Label 
-                        Style="{StaticResource Style.Core.Label.Default}" 
-                        LineBreakMode="WordWrap" 
-                        Text="{Binding Translator}"
-                        FontSize="12"
-                        />
-                </StackLayout>
-            </Grid>
-        </ViewCell>
+                <!-- Translator -->
+                <Label 
+                    Style="{StaticResource Style.Core.Label.Default}" 
+                    LineBreakMode="WordWrap" 
+                    Text="{Binding Translator}"
+                    FontSize="12"
+                    />
+            </StackLayout>
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="DataTemplate.Core.LocalizationInfo.Selected" x:DataType="language:LocalizationInfo">
-        <ViewCell>
-            <Grid 
-                Padding="2"
-                Margin="1"
-                Background="{DynamicResource PrimaryColor}"
-                ColumnDefinitions="48,*"
+        <Grid 
+            Padding="2"
+            Margin="1"
+            Background="{DynamicResource PrimaryColor}"
+            ColumnDefinitions="48,*"
+            RowDefinitions="{OnIdiom Tablet=80, Default=60}"
+            >
+            <!-- Flag -->
+            <Image 
+                HeightRequest="24"                                          
+                Source="{Binding FlagUri, Converter={StaticResource UriToStringConverter}}"
+                />
+            <!-- Infos -->
+            <StackLayout 
+                Grid.Column="1" 
+                Spacing="1" 
+                Padding="2,5,-10,0"
+                CompressedLayout.IsHeadless="true"
                 >
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="{OnIdiom Tablet=80, Default=60}" />
-                </Grid.RowDefinitions>
-
-                <!-- Flag -->
-                <Image 
-                    HeightRequest="24"                                          
-                    Source="{Binding FlagUri, Converter={StaticResource UriToStringConverter}}"
+                <!-- Language name -->
+                <Label 
+                    LineBreakMode="NoWrap" 
+                    Style="{StaticResource Style.Core.Label.Primary}" 
+                    TextColor="{StaticResource White}"
+                    Text="{Binding Name}"
                     />
-
-                <!-- Infos -->
-                <StackLayout 
-                    Grid.Column="1" 
-                    Spacing="1" 
-                    Padding="2,5,-10,0"
-                    CompressedLayout.IsHeadless="true"
-                    >
-                    <!-- Language name -->
-                    <Label 
-                        LineBreakMode="NoWrap" 
-                        Style="{StaticResource Style.Core.Label.Primary}" 
-                        TextColor="{StaticResource White}"
-                        Text="{Binding Name}"
-                        />
-                    <!-- Translator -->
-                    <Label 
-                        Style="{StaticResource Style.Core.Label.Default}" 
-                        LineBreakMode="WordWrap" 
-                        Text="{Binding Translator}"
-                        TextColor="{StaticResource White}"
-                        FontSize="12"
-                        />
+                <!-- Translator -->
+                <Label 
+                    Style="{StaticResource Style.Core.Label.Default}" 
+                    LineBreakMode="WordWrap" 
+                    Text="{Binding Translator}"
+                    TextColor="{StaticResource White}"
+                    FontSize="12"
+                    />
                 </StackLayout>
             </Grid>
-        </ViewCell>
     </DataTemplate>
 
     <!-- Documentation -->
     <DataTemplate x:Key="DataTemplate.Core.ChangelogInfo.Default" x:DataType="documentation:ChangelogInfo">
-        <ViewCell>
-            <Grid
-                x:Name="Grid"
-                Padding="16,12"
-                ColumnSpacing="16"
-                RowSpacing="2"
-                ColumnDefinitions="*,Auto"
+        <Grid
+            x:Name="Grid"
+            Padding="16,12"
+            ColumnSpacing="16"
+            RowSpacing="2"
+            ColumnDefinitions="*,Auto"
+            >
+            <Label
+                Style="{StaticResource Style.Core.Label.Default}"
+                LineBreakMode="WordWrap"
+                Text="{Binding Changelog}"
+                />
+            <Border 
+                Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
+                Style="{StaticResource Style.Core.Border.Profile}"
+                Grid.Column="1"
+                VerticalOptions="Center"
                 >
                 <Label
-                    Style="{StaticResource Style.Core.Label.Default}"
-                    LineBreakMode="WordWrap"
-                    Text="{Binding Changelog}"
+                    Margin="4"
+                    Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
+                    Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
+                    VerticalTextAlignment="Center"
+                    HorizontalTextAlignment="Center"
                     />
-                <Border 
-                    Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
-                    Style="{StaticResource Style.Core.Border.Profile}"
-                    Grid.Column="1"
-                    VerticalOptions="Center"
-                    >
-                    <Label
-                        Margin="4"
-                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
-                        Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
-                        VerticalTextAlignment="Center"
-                        HorizontalTextAlignment="Center"
-                        />
-                </Border>
-            </Grid>
-        </ViewCell>
+            </Border>
+        </Grid>
     </DataTemplate>
 
     <DataTemplate x:Key="DataTemplate.Core.ChangeInfo.Default" x:DataType="documentation:ChangeInfo">
-        <ViewCell>
-            <Grid
-                x:Name="Grid"
-                Padding="16,12"
-                ColumnSpacing="16"
-                RowSpacing="2"
-                ColumnDefinitions="*,Auto"
+        <Grid
+            x:Name="Grid"
+            Padding="16,12"
+            ColumnSpacing="16"
+            RowSpacing="2"
+            ColumnDefinitions="*,Auto"
+            >
+            <Label
+                Style="{StaticResource Style.Core.Label.Default}"
+                LineBreakMode="WordWrap"
+                Text="{Binding Changelog}"
+                />
+            <Border 
+                Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
+                Style="{StaticResource Style.Core.Border.Profile}"
+                Grid.Column="1"
+                VerticalOptions="Center"
                 >
                 <Label
-                    Style="{StaticResource Style.Core.Label.Default}"
-                    LineBreakMode="WordWrap"
-                    Text="{Binding Changelog}"
+                    Margin="4"
+                    Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
+                    Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
+                    VerticalTextAlignment="Center"
+                    HorizontalTextAlignment="Center"
                     />
-                <Border 
-                    Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray800}}" 
-                    Style="{StaticResource Style.Core.Border.Profile}"
-                    Grid.Column="1"
-                    VerticalOptions="Center"
-                    >
-                    <Label
-                        Margin="4"
-                        Style="{StaticResource Style.Core.Label.Icon.MaterialDesign}"
-                        Text="{Binding Type, Converter={StaticResource StringToChangelogIconConverter}}"
-                        VerticalTextAlignment="Center"
-                        HorizontalTextAlignment="Center"
-                        />
-                </Border>
-            </Grid>
-        </ViewCell>
+            </Border>
+        </Grid>
     </DataTemplate>
 
     <!-- Theme -->


### PR DESCRIPTION
This PR removes all `ViewCell` parents from each `ItemTempalte`. Otherwise an exception gets thrown if the template is used in a `CollectionView`.

Fixed #530