### PR TITLE
Fixed missing `Size` for `ActivityIndicator`

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.SampleApp/AppShell.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/AppShell.xaml
@@ -16,6 +16,10 @@
     >
 
     <ShellContent
+        Title="ActivityIndicators"
+        ContentTemplate="{DataTemplate views:ActivityIndicatorsPage}"
+        Route="ActivityIndicatorsPage" />
+    <ShellContent
         Title="BoxView"
         ContentTemplate="{DataTemplate views:BoxViewsPage}"
         Route="BoxViewsPage" />

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Hosting/AppHostBuilderExtensions.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Hosting/AppHostBuilderExtensions.cs
@@ -33,6 +33,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.Hosting
             // Main view models
             builder.Services.AddSingleton<AppShellViewModel>();
             builder.Services.AddSingleton<AccordionsPageViewModel>();
+            builder.Services.AddSingleton<ActivityIndicatorsPageViewModel>();
             builder.Services.AddSingleton<BordersPageViewModel>();
             builder.Services.AddSingleton<ButtonsPageViewModel>();
             builder.Services.AddSingleton<CheckBoxesPageViewModel>();
@@ -60,6 +61,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.Hosting
             builder.Services.AddSingleton<AppShell>();
             // Main view models
             builder.Services.AddSingleton<AccordionsPage>();
+            builder.Services.AddSingleton<ActivityIndicatorsPage>();
             builder.Services.AddSingleton<BordersPage>();
             builder.Services.AddSingleton<ButtonsPage>();
             builder.Services.AddSingleton<BoxViewsPage>();

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -58,6 +58,12 @@
 	  <Compile Update="Views\BordersPage.xaml.cs">
 	    <DependentUpon>BordersPage.xaml</DependentUpon>
 	  </Compile>
+	  <Compile Update="Views\ActivityIndicatorsPage.xaml.cs">
+	    <DependentUpon>ActivityIndicatorsPage.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="Views\CollectionViewPage.xaml.cs">
+	    <DependentUpon>CollectionViewPage.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Views\SfCheckBoxesPage.xaml.cs">
 	    <DependentUpon>SfCheckBoxesPage.xaml</DependentUpon>
 	  </Compile>
@@ -125,6 +131,12 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\BordersPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\ActivityIndicatorsPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\CollectionViewPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\SfCheckBoxesPage.xaml">

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/ViewModels/ActivityIndicatorsPageViewModel.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/ViewModels/ActivityIndicatorsPageViewModel.cs
@@ -1,0 +1,25 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SharedMauiXamlStylesLibrary.SampleApp.ViewModels
+{
+    public partial class ActivityIndicatorsPageViewModel : BaseViewModel
+    {
+
+        #region Properties
+
+        [ObservableProperty]
+        bool busy = true;
+        #endregion
+
+        #region Constructor, LoadSettings
+
+        public ActivityIndicatorsPageViewModel(IDispatcher dispatcher, IServiceProvider provider) : base(dispatcher, provider)
+        {
+            Dispatcher = dispatcher;
+            UpdateVersionBuild();
+        }
+
+        #endregion
+
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ActivityIndicatorsPage.xaml
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ActivityIndicatorsPage.xaml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="SharedMauiXamlStylesLibrary.SampleApp.Views.ActivityIndicatorsPage"
+    
+    xmlns:viewModels="clr-namespace:SharedMauiXamlStylesLibrary.SampleApp.ViewModels"
+    
+    xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons;assembly=SharedMauiXamlStylesLibrary.Syncfusion"
+    
+    Title="ActivityIndicatorsPage"
+    Style="{StaticResource Style.Core.ContentPage.Default}"
+    x:DataType="viewModels:ActivityIndicatorsPageViewModel"   
+    >
+    <ScrollView>
+        <VerticalStackLayout>
+            <Label 
+                Margin="2,8"
+                Text="Activity"
+                VerticalTextAlignment="Center" 
+                HorizontalTextAlignment="Center"
+                Style="{StaticResource Style.Core.Label.Medium}"
+                />
+            <Grid
+                ColumnDefinitions="*,*"
+                >
+                <ActivityIndicator
+                    Margin="10"
+                    IsRunning="{Binding Busy}"
+                    />
+                <ActivityIndicator
+                    Style="{StaticResource Style.Core.ActivityIndicator.Primary}"
+                    Grid.Column="1"
+                    Margin="10"
+                    IsRunning="{Binding Busy}"
+                    />
+            </Grid>
+            <Grid
+                ColumnDefinitions="Auto,*"
+                >
+                <CheckBox
+                    IsChecked="{Binding Busy}"
+                    Style="{StaticResource Style.Core.CheckBox.Default}"
+                    />
+                <Label 
+                    Grid.Column="1"
+                    Margin="2,8"
+                    Text="Toggle busy state"
+                    VerticalTextAlignment="Center" 
+                    HorizontalTextAlignment="Start"
+                    Style="{StaticResource Style.Core.Label.Settings}"
+                    />
+            </Grid>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ActivityIndicatorsPage.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Views/ActivityIndicatorsPage.xaml.cs
@@ -1,0 +1,12 @@
+using SharedMauiXamlStylesLibrary.SampleApp.ViewModels;
+
+namespace SharedMauiXamlStylesLibrary.SampleApp.Views;
+
+public partial class ActivityIndicatorsPage : ContentPage
+{
+    public ActivityIndicatorsPage(ActivityIndicatorsPageViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ActivityIndicator.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/Controls/ActivityIndicator.xaml
@@ -10,6 +10,8 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="Style.Core.ActivityIndicator.Default" TargetType="ActivityIndicator">
+        <Setter Property="WidthRequest" Value="64" />
+        <Setter Property="HeightRequest" Value="64" />
         <Setter Property="Color" Value="{AppThemeBinding Light={DynamicResource PrimaryColor}, Dark={StaticResource White}}" />
     </Style>
 


### PR DESCRIPTION
This PR adds the missing `Width` and `Height` for the `ActivityIndicator`.

Fixed #541