### PR TITLE
Updated nugets

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -217,14 +217,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
 	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.14-preview2" />
-	  <PackageReference Include="System.Text.Json" Version="9.0.2" />
+	  <PackageReference Include="System.Text.Json" Version="9.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.40" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.40" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.50" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 	</ItemGroup>
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -28,42 +28,42 @@
 	
 	<ItemGroup>
 		<ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.40" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.40" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.50" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 		<PackageReference Include="SharedMauiCoreLibrary" Version="1.1.14-preview2" />
-		<PackageReference Include="Syncfusion.Maui.AIAssistView" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Backdrop" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Barcode" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Buttons" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Calendar" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Cards" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Carousel" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Charts" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Core" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.DataForm" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.DataGrid" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Expander" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Gauges" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.ImageEditor" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Inputs" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Kanban" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.ListView" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.NavigationDrawer" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.ParallaxView" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.PdfViewer" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Picker" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.ProgressBar" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.PullToRefresh" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.RadialMenu" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Rotator" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Scheduler" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.SignaturePad" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.Sliders" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.SunburstChart" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.TabView" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.TreeMap" Version="28.2.6" />
-		<PackageReference Include="Syncfusion.Maui.TreeView" Version="28.2.6" />
+		<PackageReference Include="Syncfusion.Maui.AIAssistView" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Backdrop" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Barcode" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Buttons" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Calendar" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Cards" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Carousel" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Charts" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Core" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.DataForm" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.DataGrid" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Expander" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Gauges" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.ImageEditor" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Inputs" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Kanban" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.ListView" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.NavigationDrawer" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.ParallaxView" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.PdfViewer" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Picker" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.ProgressBar" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.PullToRefresh" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.RadialMenu" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Rotator" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Scheduler" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.SignaturePad" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.Sliders" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.SunburstChart" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.TabView" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.TreeMap" Version="28.2.11" />
+		<PackageReference Include="Syncfusion.Maui.TreeView" Version="28.2.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -143,9 +143,9 @@
 	  <Folder Include="Licenses\LicenseFiles\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.40" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.40" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.50" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 	</ItemGroup>
 
 	<!-- https://github.com/mattleibow/PackagingMauiAssets/blob/main/MauiLibrary/MauiLibrary.csproj -->


### PR DESCRIPTION
The issue with the `Text` showing only after `Hover` was not a library bug. However, this PR updates all nugets.

Fixed #606