### PR TITLE
Converted `DataTemplate` without `Type` to a `ControlTemplate`

### DIFF
--- a/framework.maui.props
+++ b/framework.maui.props
@@ -16,7 +16,9 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PublishReadyToRun>false</PublishReadyToRun>
 		<IsRidAgnostic Condition="'$(OutputType)' == 'Library'">true</IsRidAgnostic>
-
+		
+		<!-- Compiled bindings -->
+		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 		<!-- Needed with latest SDK 8 version? -->
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeBasementView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeBasementView.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.ContentViews.SwipeBasementView"
+    
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.Syncfusion.ContentViews"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    >
+    <ContentView.ControlTemplate>
+        <ControlTemplate x:DataType="contentViews:SwipeBasementView">
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                Text="{Binding IconText}"
+                FontFamily="{Binding IconFontFamily}"
+                TextColor="{Binding IconFontBrush}"
+                Background="{Binding Background}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding SwipeCommand}"
+                        CommandParameter="{Binding SwipeCommandParameter}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+</ContentView>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeBasementView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeBasementView.xaml.cs
@@ -1,0 +1,50 @@
+namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
+
+public partial class SwipeBasementView : ContentView
+{
+    #region Bindings
+
+    public static readonly BindableProperty IconTextProperty = BindableProperty.Create(nameof(IconText), typeof(string), typeof(AccountConventView), string.Empty);
+    public static readonly BindableProperty IconFontBrushProperty = BindableProperty.Create(nameof(IconFontBrush), typeof(Brush), typeof(SwipeBasementView), Brush.Black);
+    public static readonly BindableProperty IconFontFamilyProperty = BindableProperty.Create(nameof(IconFontFamily), typeof(string), typeof(SwipeBasementView), "MaterialDesignIcons");
+
+    public static readonly BindableProperty SwipeCommandProperty = BindableProperty.Create(nameof(SwipeCommand), typeof(Command), typeof(SwipeBasementView), null);
+    public static readonly BindableProperty SwipeCommandParameterProperty = BindableProperty.Create(nameof(SwipeCommandParameter), typeof(object), typeof(SwipeBasementView), null);
+
+    #endregion
+
+    #region Properties
+
+    public string IconText
+    {
+        get => (string)GetValue(IconTextProperty);
+        set => SetValue(IconTextProperty, value);
+    }
+    public string IconFontFamily
+    {
+        get => (string)GetValue(IconFontFamilyProperty);
+        set => SetValue(IconFontFamilyProperty, value);
+    }
+    public Brush IconFontBrush
+    {
+        get => (Brush)GetValue(IconFontBrushProperty);
+        set => SetValue(IconFontBrushProperty, value);
+    }
+
+    public string SwipeCommand
+    {
+        get => (string)GetValue(SwipeCommandProperty);
+        set => SetValue(SwipeCommandProperty, value);
+    }
+    public object SwipeCommandParameter
+    {
+        get => GetValue(SwipeCommandParameterProperty);
+        set => SetValue(SwipeCommandParameterProperty, value);
+    }
+    #endregion
+
+    public SwipeBasementView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeDeleteView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeDeleteView.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.ContentViews.SwipeDeleteView"
+    
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.Syncfusion.ContentViews"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    >
+    <ContentView.ControlTemplate>
+        <ControlTemplate x:DataType="contentViews:SwipeDeleteView">
+            <contentViews:SwipeBasementView
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                IconText="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
+                IconFontFamily="{StaticResource FontIcons}"
+                IconFontBrush="{StaticResource White}"
+                Background="{StaticResource Red}"
+                SwipeCommand="{Binding DeleteCommand}"
+                SwipeCommandParameter="{Binding DeleteCommandParameter}"
+                />
+            <!--
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Delete}"
+                TextColor="{StaticResource White}"
+                Background="{StaticResource Red}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding DeleteCommand}"
+                        CommandParameter="{Binding DeleteCommandParameter}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            -->
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+</ContentView>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeDeleteView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeDeleteView.xaml.cs
@@ -1,0 +1,30 @@
+namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
+
+public partial class SwipeDeleteView : ContentView
+{
+    #region Bindings
+
+    public static readonly BindableProperty DeleteCommandProperty = BindableProperty.Create(nameof(DeleteCommand), typeof(Command), typeof(SwipeDeleteView), null);
+    public static readonly BindableProperty DeleteCommandParameterProperty = BindableProperty.Create(nameof(DeleteCommandParameter), typeof(object), typeof(SwipeDeleteView), null);
+
+    #endregion
+
+    #region Properties
+
+    public string DeleteCommand
+    {
+        get => (string)GetValue(DeleteCommandProperty);
+        set => SetValue(DeleteCommandProperty, value);
+    }
+    public object DeleteCommandParameter
+    {
+        get => GetValue(DeleteCommandParameterProperty);
+        set => SetValue(DeleteCommandParameterProperty, value);
+    }
+    #endregion
+
+    public SwipeDeleteView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeEditView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeEditView.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.ContentViews.SwipeEditView"
+    
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.Syncfusion.ContentViews"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    >
+    <ContentView.ControlTemplate>
+        <ControlTemplate x:DataType="contentViews:SwipeEditView">
+            <contentViews:SwipeBasementView
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                IconText="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
+                IconFontFamily="{StaticResource FontIcons}"
+                IconFontBrush="{StaticResource White}"
+                Background="{StaticResource Green}"
+                SwipeCommand="{Binding EditCommand}"
+                SwipeCommandParameter="{Binding EditCommandParameter}"
+                />
+            <!--
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Edit}"
+                TextColor="{StaticResource White}"
+                Background="{StaticResource Green}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding EditCommand}"
+                        CommandParameter="{Binding EditCommandParameter}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            -->
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+</ContentView>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeEditView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeEditView.xaml.cs
@@ -1,0 +1,30 @@
+namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
+
+public partial class SwipeEditView : ContentView
+{
+    #region Bindings
+
+    public static readonly BindableProperty EditCommandProperty = BindableProperty.Create(nameof(EditCommand), typeof(Command), typeof(SwipeEditView), null);
+    public static readonly BindableProperty EditCommandParameterProperty = BindableProperty.Create(nameof(EditCommandParameter), typeof(object), typeof(SwipeEditView), null);
+
+    #endregion
+
+    #region Properties
+
+    public string EditCommand
+    {
+        get => (string)GetValue(EditCommandProperty);
+        set => SetValue(EditCommandProperty, value);
+    }
+    public object EditCommandParameter
+    {
+        get => GetValue(EditCommandParameterProperty);
+        set => SetValue(EditCommandParameterProperty, value);
+    }
+    #endregion
+
+    public SwipeEditView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrint3dView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrint3dView.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.ContentViews.SwipePrint3dView"
+    
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.Syncfusion.ContentViews"
+    xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    >
+    <ContentView.ControlTemplate>
+        <ControlTemplate x:DataType="contentViews:SwipePrint3dView">
+            <contentViews:SwipeBasementView
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                IconText="{x:Static icons:MaterialIcons.Printer3dNozzleOutline}"
+                IconFontFamily="{StaticResource MaterialDesignIcons}"
+                IconFontBrush="{StaticResource White}"
+                Background="{StaticResource Green}"
+                SwipeCommand="{Binding PrintCommand}"
+                SwipeCommandParameter="{Binding PrintCommandParameter}"
+                />
+            <!--
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                TextColor="{StaticResource White}"
+                Background="{StaticResource Green}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding PrintCommand}"
+                        CommandParameter="{Binding PrintCommandParameter}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            -->
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+</ContentView>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrint3dView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrint3dView.xaml.cs
@@ -1,0 +1,30 @@
+namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
+
+public partial class SwipePrint3dView : ContentView
+{
+    #region Bindings
+
+    public static readonly BindableProperty PrintCommandProperty = BindableProperty.Create(nameof(PrintCommand), typeof(Command), typeof(SwipePrint3dView), null);
+    public static readonly BindableProperty PrintCommandParameterProperty = BindableProperty.Create(nameof(PrintCommandParameter), typeof(object), typeof(SwipePrint3dView), null);
+
+    #endregion
+
+    #region Properties
+
+    public string PrintCommand
+    {
+        get => (string)GetValue(PrintCommandProperty);
+        set => SetValue(PrintCommandProperty, value);
+    }
+    public object PrintCommandParameter
+    {
+        get => GetValue(PrintCommandParameterProperty);
+        set => SetValue(PrintCommandParameterProperty, value);
+    }
+    #endregion
+
+    public SwipePrint3dView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrintView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrintView.xaml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.ContentViews.SwipePrintView"
+    
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.Syncfusion.ContentViews"
+    xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    >
+    <ContentView.ControlTemplate>
+        <ControlTemplate x:DataType="contentViews:SwipePrintView">
+            <contentViews:SwipeBasementView
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                IconText="{x:Static icons:MaterialIcons.Printer}"
+                IconFontFamily="{StaticResource MaterialDesignIcons}"
+                IconFontBrush="{StaticResource White}"
+                Background="{StaticResource Green}"
+                SwipeCommand="{Binding PrintCommand}"
+                SwipeCommandParameter="{Binding PrintCommandParameter}"
+                />
+            <!--
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                Text="{x:Static icons:MaterialIcons.Printer}"
+                TextColor="{StaticResource White}"
+                Background="{StaticResource Green}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding PrintCommand}"
+                        CommandParameter="{Binding PrintCommandParameter}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            -->
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+</ContentView>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrintView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipePrintView.xaml.cs
@@ -1,0 +1,30 @@
+namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
+
+public partial class SwipePrintView : ContentView
+{
+    #region Bindings
+
+    public static readonly BindableProperty PrintCommandProperty = BindableProperty.Create(nameof(PrintCommand), typeof(Command), typeof(SwipePrintView), null);
+    public static readonly BindableProperty PrintCommandParameterProperty = BindableProperty.Create(nameof(PrintCommandParameter), typeof(object), typeof(SwipePrintView), null);
+
+    #endregion
+
+    #region Properties
+
+    public string PrintCommand
+    {
+        get => (string)GetValue(PrintCommandProperty);
+        set => SetValue(PrintCommandProperty, value);
+    }
+    public object PrintCommandParameter
+    {
+        get => GetValue(PrintCommandParameterProperty);
+        set => SetValue(PrintCommandParameterProperty, value);
+    }
+    #endregion
+
+    public SwipePrintView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeShowView.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeShowView.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Syncfusion.ContentViews.SwipeShowView"
+    
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.Syncfusion.ContentViews"
+    xmlns:iconsSyncfusion="clr-namespace:AndreasReitberger.Shared.Syncfusion.FontIcons"
+    >
+    <ContentView.ControlTemplate>
+        <ControlTemplate x:DataType="contentViews:SwipeShowView">
+            <contentViews:SwipeBasementView
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                IconText="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
+                IconFontFamily="{StaticResource FontIcons}"
+                IconFontBrush="{StaticResource White}"
+                Background="{StaticResource Blue}"
+                SwipeCommand="{Binding ShowCommand}"
+                SwipeCommandParameter="{Binding ShowCommandParameter}"
+                />
+            <!--
+            <Label
+                Style="{StaticResource Style.Core.Label.Icon}"
+                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+                Text="{x:Static iconsSyncfusion:SyncfusionIcons.Show}"
+                TextColor="{StaticResource White}"
+                Background="{StaticResource Blue}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Margin="0"
+                >
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer
+                        NumberOfTapsRequired="1"
+                        Command="{Binding ShowCommand}"
+                        CommandParameter="{Binding ShowCommandParameter}"
+                        />
+                </Label.GestureRecognizers>
+            </Label>
+            -->
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+</ContentView>

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeShowView.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/ContentViews/SwipeShowView.xaml.cs
@@ -1,0 +1,30 @@
+namespace AndreasReitberger.Shared.Syncfusion.ContentViews;
+
+public partial class SwipeShowView : ContentView
+{
+    #region Bindings
+
+    public static readonly BindableProperty ShowCommandProperty = BindableProperty.Create(nameof(ShowCommand), typeof(Command), typeof(SwipeShowView), null);
+    public static readonly BindableProperty ShowCommandParameterProperty = BindableProperty.Create(nameof(ShowCommandParameter), typeof(object), typeof(SwipeShowView), null);
+
+    #endregion
+
+    #region Properties
+
+    public string ShowCommand
+    {
+        get => (string)GetValue(ShowCommandProperty);
+        set => SetValue(ShowCommandProperty, value);
+    }
+    public object ShowCommandParameter
+    {
+        get => GetValue(ShowCommandParameterProperty);
+        set => SetValue(ShowCommandParameterProperty, value);
+    }
+    #endregion
+
+    public SwipeShowView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewGroupHeaderTemplates.xaml
@@ -37,7 +37,6 @@
                     </Style>
                 </Label.Style>
             </Label>
-
             <Label 
                 Text="{Binding Key}" 
                 Style="{StaticResource Style.Core.Label.GroupingHeader}"

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/Resources/Themes/ItemTemplates/ListViewHeaderTemplates.xaml
@@ -5,8 +5,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Syncfusion.Themes.ItemTemplates.ListViewHeaderTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
     
     xmlns:icons="clr-namespace:AndreasReitberger.Shared.FontIcons;assembly=SharedMauiXamlStylesLibrary"

--- a/src/SharedMauiXamlStylesLibrary/ContentViews/AccountConventView.xaml
+++ b/src/SharedMauiXamlStylesLibrary/ContentViews/AccountConventView.xaml
@@ -5,57 +5,5 @@
     x:Class="AndreasReitberger.Shared.ContentViews.AccountConventView"
     
     xmlns:conventViews="clr-namespace:AndreasReitberger.Shared.ContentViews"
-    xmlns:shared="clr-namespace:AndreasReitberger.Shared;assembly=SharedMauiXamlStylesLibrary"
-    >
-    <ContentView.Resources>
-        <shared:SharedConverters />
-    </ContentView.Resources>
-    
-    <ContentView.ControlTemplate>
-        <ControlTemplate x:DataType="conventViews:AccountConventView">
-            <Grid
-                Style="{StaticResource Style.Core.Grid.ShellTitleView}"
-                BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
-                IsVisible="{Binding IsVisible}"
-                IsEnabled="{Binding IsEnabled}"
-                Background="{Binding Background}"
-                HeightRequest="{Binding HeightRequest}"
-                ColumnDefinitions="*,Auto,Auto"
-                >
-                <ContentPresenter
-                    IsVisible="{Binding IsSyncing, Converter={StaticResource BooleanReverseVisibilityConverter}}"
-                    />
-                <HorizontalStackLayout
-                    Grid.Column="1"
-                    IsVisible="{Binding IsSyncing}"
-                    >
-                    <ActivityIndicator
-                        Margin="2"
-                        IsRunning="{Binding IsSyncing}"
-                        Style="{StaticResource Style.Core.ActivityIndicator.Default}"
-                        />
-                    <Label
-                        Margin="4,2"
-                        Text="{Binding IsSyncingText}"
-                        Style="{StaticResource Style.Core.Label.Small}"
-                        VerticalTextAlignment="Center"
-                        HorizontalTextAlignment="Start"
-                        />
-                </HorizontalStackLayout>
-                <Border
-                    IsVisible="{Binding IsSyncing, Converter={StaticResource BooleanReverseVisibilityConverter}}"                   
-                    HeightRequest="{Binding HeightRequest}"
-                    WidthRequest="50"
-                    Grid.Column="2"
-                    Style="{StaticResource Style.Core.Border.Profile}"
-                    StrokeShape="RoundRectangle 25"
-                    >
-                    <Image             
-                        Source="{Binding UserImage}"
-                        Aspect="AspectFit"
-                        />
-                </Border>
-            </Grid>
-        </ControlTemplate>
-    </ContentView.ControlTemplate>
-</ContentView>
+    ControlTemplate="{StaticResource ControlTemplate.Core.Account}"
+    />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ControlTemplates/ControlTemplate.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ControlTemplates/ControlTemplate.xaml
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.Themes.ControlTemplates.ControlTemplate"
+        
+    xmlns:contentViews="clr-namespace:AndreasReitberger.Shared.ContentViews"
+    >
+    <!---->
+    <ControlTemplate x:Key="ControlTemplate.Core.Account" x:DataType="contentViews:AccountConventView">
+        <Grid
+            Style="{StaticResource Style.Core.Grid.ShellTitleView}"
+            BindingContext="{Binding Source={RelativeSource TemplatedParent}}"
+            IsVisible="{Binding IsVisible}"
+            IsEnabled="{Binding IsEnabled}"
+            Background="{Binding Background}"
+            HeightRequest="{Binding HeightRequest}"
+            ColumnDefinitions="*,Auto,Auto"
+            >
+            <ContentPresenter
+                IsVisible="{Binding IsSyncing, Converter={StaticResource BooleanReverseVisibilityConverter}}"
+                />
+            <HorizontalStackLayout
+                Grid.Column="1"
+                IsVisible="{Binding IsSyncing}"
+                >
+                <ActivityIndicator
+                    Margin="2"
+                    IsRunning="{Binding IsSyncing}"
+                    Style="{StaticResource Style.Core.ActivityIndicator.Default}"
+                    />
+                <Label
+                    Margin="4,2"
+                    Text="{Binding IsSyncingText}"
+                    Style="{StaticResource Style.Core.Label.Small}"
+                    VerticalTextAlignment="Center"
+                    HorizontalTextAlignment="Start"
+                    />
+            </HorizontalStackLayout>
+            <Border
+                IsVisible="{Binding IsSyncing, Converter={StaticResource BooleanReverseVisibilityConverter}}"                   
+                HeightRequest="{Binding HeightRequest}"
+                WidthRequest="50"
+                Grid.Column="2"
+                Style="{StaticResource Style.Core.Border.Profile}"
+                StrokeShape="RoundRectangle 25"
+                >
+                <Image             
+                    Source="{Binding UserImage}"
+                    Aspect="AspectFit"
+                    />
+            </Border>
+        </Grid>
+    </ControlTemplate>
+    <!---->
+</ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ControlTemplates/ControlTemplate.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ControlTemplates/ControlTemplate.xaml.cs
@@ -1,0 +1,9 @@
+namespace AndreasReitberger.Shared.Themes.ControlTemplates;
+
+public partial class ControlTemplate : ResourceDictionary
+{
+    public ControlTemplate()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/DefaultTheme.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/DefaultTheme.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary Source="/Resources/Themes/SharedColors.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedFonts.xaml" />
         <!-- Templates must come for styles! -->
+        <ResourceDictionary Source="/Resources/Themes/SharedControlTemplates.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedTemplates.xaml" />
         <ResourceDictionary Source="/Resources/Themes/SharedStyles.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewHeaderTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/ItemTemplates/ListViewHeaderTemplates.xaml
@@ -5,10 +5,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AndreasReitberger.Shared.Themes.ItemTemplates.ListViewHeaderTemplates"
     
-    xmlns:eventLogger="clr-namespace:AndreasReitberger.Shared.Core.EventLogger;assembly=SharedMauiCoreLibrary"
-    xmlns:documentation="clr-namespace:AndreasReitberger.Shared.Core.Documentation;assembly=SharedMauiCoreLibrary"
-    xmlns:language="clr-namespace:AndreasReitberger.Shared.Core.Localization;assembly=SharedMauiCoreLibrary"
-    
     xmlns:converters="clr-namespace:AndreasReitberger.Shared.Core.Converters;assembly=SharedMauiCoreLibrary"
     >
     <converters:UriToStringConverter x:Key="UriToStringConverter" />

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedControlTemplates.xaml
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedControlTemplates.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="AndreasReitberger.Shared.ControlTemplates"
+    >
+    <ResourceDictionary.MergedDictionaries>
+        <!-- Control Templates -->
+        <ResourceDictionary Source="/Resources/Themes/ControlTemplates/ControlTemplate.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedControlTemplates.xaml.cs
+++ b/src/SharedMauiXamlStylesLibrary/Resources/Themes/SharedControlTemplates.xaml.cs
@@ -1,0 +1,9 @@
+namespace AndreasReitberger.Shared;
+
+public partial class ControlTemplates
+{
+    public ControlTemplates()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -79,6 +79,9 @@
 	  <Compile Update="Resources\Themes\SharedFontSizes.xaml.cs">
 	    <DependentUpon>SharedFontSizes.xaml</DependentUpon>
 	  </Compile>
+	  <Compile Update="Resources\Themes\SharedControlTemplates.xaml.cs">
+	    <DependentUpon>SharedControlTemplates.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Resources\Themes\SharedTemplates.xaml.cs">
 	    <DependentUpon>SharedTemplates.xaml</DependentUpon>
 	  </Compile>
@@ -98,6 +101,10 @@
 	    <SubType>Code</SubType>
 	    <DependentUpon>GeneralItemTemplates.xaml</DependentUpon>
 	  </Compile>
+	<Compile Update="Resources\Themes\ControlTemplates\ControlTemplate.xaml.cs">
+		<SubType>Code</SubType>
+		<DependentUpon>ControlTemplate.xaml</DependentUpon>
+	</Compile>
 	  <Compile Update="Resources\Themes\ItemTemplates\ListViewItemTemplates.xaml.cs">
 	    <DependentUpon>%(Filename)</DependentUpon>
 	  </Compile>
@@ -133,6 +140,9 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Resources\Themes\Controls\CollectionView.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Resources\Themes\ControlTemplates\ControlTemplate.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Resources\Themes\SharedConverters.xaml">


### PR DESCRIPTION
This PR creates `ControlTemplates` for `DataTemplates` which have no actual `Type` as `x:DataType`.
Mostly all templates which are bound to a `ViewModel` later.

Fixed #619