### PR TITLE
Removed `Microsoft.Maui.Controls.Compatibility`

### DIFF
--- a/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/SharedMauiXamlStylesLibrary.SampleApp.csproj
@@ -217,14 +217,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.14" />
-	  <PackageReference Include="System.Text.Json" Version="9.0.3" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.50" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.15" />
+	  <PackageReference Include="System.Text.Json" Version="9.0.4" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.60" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.4" />
 	</ItemGroup>
 </Project>

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/Utilities/ThemeManager.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/Utilities/ThemeManager.cs
@@ -118,12 +118,12 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.Utilities
         /// Updates the `PrimaryColor` for platform specific resources, as the StatusBar
         /// </summary>
         /// <param name="theme">The ThemeColorInfo to be changed to</param>
-        public void UpdatePlatformThemeColor(ThemeColorInfo? theme)
+        public static void UpdatePlatformThemeColor(ThemeColorInfo? theme)
         {
             try
             {
                 if (theme?.PrimaryColor is not null)
-                    new PlatformThemeService()?.SetStatusBarColor(theme.PrimaryColor);
+                    PlatformThemeService.SetStatusBarColor(theme.PrimaryColor);
             }
             catch (Exception exc)
             {
@@ -136,7 +136,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.Utilities
 
         public ThemeColorInfo? FindThemeOrDefault(string primaryColorHexCode) => FindTheme(primaryColorHexCode) ?? AppDefaultTheme;
 
-        public Color? GetThemeColorFromResource(string resourceName, Application? app = null)
+        public static Color? GetThemeColorFromResource(string resourceName, Application? app = null)
         {
             try
             {

--- a/src/SharedMauiXamlStylesLibrary.SampleApp/ViewModels/BaseViewModel.cs
+++ b/src/SharedMauiXamlStylesLibrary.SampleApp/ViewModels/BaseViewModel.cs
@@ -74,7 +74,7 @@ namespace SharedMauiXamlStylesLibrary.SampleApp.ViewModels
                 //SettingsApp.Theme_PrimaryThemeColor = value;
                 //SettingsApp.SettingsChanged = true;
                 ThemeManager.Instance.UpdatePrimaryThemeColor(ThemeManager.Instance.FindThemeOrDefault(value), Application.Current);
-                ThemeManager.Instance.UpdatePlatformThemeColor(ThemeManager.Instance.FindThemeOrDefault(value));
+                ThemeManager.UpdatePlatformThemeColor(ThemeManager.Instance.FindThemeOrDefault(value));
             }
         }
         #endregion

--- a/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
+++ b/src/SharedMauiXamlStylesLibrary.Syncfusion/SharedMauiXamlStylesLibrary.Syncfusion.csproj
@@ -28,42 +28,41 @@
 	
 	<ItemGroup>
 		<ProjectReference Include="..\SharedMauiXamlStylesLibrary\SharedMauiXamlStylesLibrary.csproj" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.50" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
-		<PackageReference Include="SharedMauiCoreLibrary" Version="1.1.14" />
-		<PackageReference Include="Syncfusion.Maui.AIAssistView" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Backdrop" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Barcode" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Buttons" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Calendar" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Cards" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Carousel" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Charts" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Core" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.DataForm" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.DataGrid" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Expander" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Gauges" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.ImageEditor" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Inputs" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Kanban" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.ListView" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.NavigationDrawer" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.ParallaxView" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.PdfViewer" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Picker" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.ProgressBar" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.PullToRefresh" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.RadialMenu" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Rotator" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Scheduler" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.SignaturePad" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.Sliders" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.SunburstChart" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.TabView" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.TreeMap" Version="28.2.11" />
-		<PackageReference Include="Syncfusion.Maui.TreeView" Version="28.2.11" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.60" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.4" />
+		<PackageReference Include="SharedMauiCoreLibrary" Version="1.1.15" />
+		<PackageReference Include="Syncfusion.Maui.AIAssistView" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Backdrop" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Barcode" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Buttons" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Calendar" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Cards" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Carousel" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Charts" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Core" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.DataForm" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.DataGrid" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Expander" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Gauges" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.ImageEditor" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Inputs" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Kanban" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.ListView" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.NavigationDrawer" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.ParallaxView" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.PdfViewer" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Picker" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.ProgressBar" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.PullToRefresh" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.RadialMenu" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Rotator" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Scheduler" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.SignaturePad" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.Sliders" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.SunburstChart" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.TabView" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.TreeMap" Version="29.1.39" />
+		<PackageReference Include="Syncfusion.Maui.TreeView" Version="29.1.39" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
+++ b/src/SharedMauiXamlStylesLibrary/SharedMauiXamlStylesLibrary.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.14" />
+	  <PackageReference Include="SharedMauiCoreLibrary" Version="1.1.15" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -143,9 +143,8 @@
 	  <Folder Include="Licenses\LicenseFiles\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.50" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.60" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.4" />
 	</ItemGroup>
 
 	<!-- https://github.com/mattleibow/PackagingMauiAssets/blob/main/MauiLibrary/MauiLibrary.csproj -->


### PR DESCRIPTION
This commit removes the `Microsoft.Maui.Controls.Compatibility` nuget. Also all other nugets have been updated.

Fixed #621